### PR TITLE
Fix NaNs in nonlinear solver

### DIFF
--- a/src/SeaIceThermodynamics/HeatBoundaryConditions/top_heat_boundary_conditions.jl
+++ b/src/SeaIceThermodynamics/HeatBoundaryConditions/top_heat_boundary_conditions.jl
@@ -96,5 +96,7 @@ using RootSolvers: SecantMethod, find_zero, CompactSolution
 
     solution = find_zero(flux_balance, method, solution_type)
 
-    return solution.root
+    h = @inbounds model_fields.h[i, j, 1]
+        
+    return ifelse(h > 0, solution.root, Tu)
 end


### PR DESCRIPTION
When `h = 0`, the internal flux is zero and does not depend on the input temperature.
For this reason, a root solver cannot find a solution for T, which ends up being NaN.
