### PR TITLE
(0.2.1) Don't import unused `active_linear_index_to_tuple`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaSeaIce"
 uuid = "6ba0ff68-24e6-4315-936c-2e99227c95a4"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/SeaIceMomentumEquations/momentum_tendencies_kernel_functions.jl
+++ b/src/SeaIceMomentumEquations/momentum_tendencies_kernel_functions.jl
@@ -1,5 +1,4 @@
 using Oceananigans.Coriolis: y_f_cross_U, x_f_cross_U
-using Oceananigans.ImmersedBoundaries: active_linear_index_to_tuple
 
 """compute explicit ice u-velocity tendencies"""
 @inline function u_velocity_tendency(i, j, grid, Δt,

--- a/src/SeaIceMomentumEquations/split_explicit_momentum_equations.jl
+++ b/src/SeaIceMomentumEquations/split_explicit_momentum_equations.jl
@@ -2,7 +2,7 @@ using Oceananigans.Grids: AbstractGrid, architecture
 using Oceananigans.BoundaryConditions: fill_halo_regions!
 using Oceananigans.Utils: configure_kernel
 using Oceananigans.TimeSteppers: store_field_tendencies!
-using Oceananigans.ImmersedBoundaries: retrieve_surface_active_cells_map, mask_immersed_field_xy!
+using Oceananigans.ImmersedBoundaries: mask_immersed_field_xy!
 
 struct SplitExplicitSolver 
     substeps :: Int


### PR DESCRIPTION
In the process of cleaning up Oceananigans I found this; regardless of whether we change the name of this function, there's no need to import it if it isn't used.