### PR TITLE
Utility function to compute total momentum stress + Fix a NaN

### DIFF
--- a/src/SeaIceMomentumEquations/sea_ice_external_stress.jl
+++ b/src/SeaIceMomentumEquations/sea_ice_external_stress.jl
@@ -26,10 +26,10 @@ using Oceananigans.Fields: ZeroField
 ##### Utility for computing the total stress
 #####
 
-@inline momentum_stress_x(i, j, k, grid, stress, clock, fields) = 
+@inline x_momentum_stress(i, j, k, grid, stress, clock, fields) = 
     @inbounds explicit_τx(i, j, k, grid, stress, clock, fields) - implicit_τx_coefficient(i, j, k, grid, stress, clock, fields) * fields.u[i, j, k]
 
-@inline momentum_stress_y(i, j, k, grid, stress, clock, fields) =
+@inline y_momentum_stress(i, j, k, grid, stress, clock, fields) =
     @inbounds explicit_τy(i, j, k, grid, stress, clock, fields) - implicit_τy_coefficient(i, j, k, grid, stress, clock, fields) * fields.v[i, j, k]
 
 #####

--- a/src/SeaIceMomentumEquations/sea_ice_external_stress.jl
+++ b/src/SeaIceMomentumEquations/sea_ice_external_stress.jl
@@ -23,6 +23,16 @@ using Oceananigans.Fields: ZeroField
 @inline explicit_τy(i, j, k, grid, stress::NamedTuple, clock, fields) = explicit_τx(i, j, k, grid, stress.v, clock, fields)
 
 #####
+##### Utility for computing the total stress
+#####
+
+@inline momentum_stress_x(i, j, k, grid, stress, clock, fields) = 
+    @inbounds explicit_τx(i, j, k, grid, stress, clock, fields) - implicit_τx_coefficient(i, j, k, grid, stress, clock, fields) * fields.u[i, j, k]
+
+@inline momentum_stress_y(i, j, k, grid, stress, clock, fields) =
+    @inbounds explicit_τy(i, j, k, grid, stress, clock, fields) - implicit_τy_coefficient(i, j, k, grid, stress, clock, fields) * fields.v[i, j, k]
+
+#####
 ##### SemiImplicitStress
 #####
 

--- a/src/SeaIceThermodynamics/thermodynamic_time_step.jl
+++ b/src/SeaIceThermodynamics/thermodynamic_time_step.jl
@@ -87,12 +87,12 @@ end
 # We parameterize the evolution of ice thickness and concentration
 # (i.e. lateral vs vertical growth) following Hibler (1979)
 @inline function concentration_thermodynamic_step(::ProportionalEvolution, ∂t_V, ℵⁿ, hⁿ, hᶜ, Δt)
-    ∂t_V_freezing = max(∂t_V, zero(ℵⁿ))
-    ∂t_V_melting  = min(∂t_V, zero(ℵⁿ))
+    freezing = (∂t_V ≥ 0) # Freezing
+    melting  = (∂t_V < 0) # Melting
 
-    ∂t_ℵᶠ = (1 - ℵⁿ) /  hᶜ * ∂t_V_freezing
-    ∂t_ℵᵐ =      ℵⁿ  / 2hⁿ * ∂t_V_melting
-    
+    ∂t_ℵᶠ = (1 - ℵⁿ) /  hᶜ * ∂t_V * freezing
+    ∂t_ℵᵐ =      ℵⁿ  / 2hⁿ * ∂t_V * melting
+
     # Update concentration accordingly
     ℵ⁺ = ℵⁿ + Δt * (∂t_ℵᶠ + ∂t_ℵᵐ)
     ℵ⁺ = max(zero(ℵ⁺), ℵ⁺)

--- a/src/SeaIceThermodynamics/thermodynamic_time_step.jl
+++ b/src/SeaIceThermodynamics/thermodynamic_time_step.jl
@@ -71,23 +71,35 @@ end
     # volume adjustment (the ice cannot produce more melt than its actual volume!)
     ∂t_V = (Vⁿ⁺¹ - hⁿ * ℵⁿ) / Δt
 
-    # We parameterize the evolution of ice thickness and concentration
-    # (i.e. lateral vs vertical growth) following Hibler (1979)
-    ∂t_ℵᶠ = (1 - ℵⁿ) * ∂t_V / hᶜ * freezing
-    ∂t_ℵᵐ = ℵⁿ * min(∂t_V, zero(ℵⁿ)) / 2hⁿ * !(freezing)
+    # There are 6 typical cases depending on the sign of ∂t_V, ℵⁿ and hⁿ
+    #
+    # - ∂t_V ≥ 0 : the ice is growing * easy case to handle *
+    # ├── ℵⁿ == 0 -> new ice is forming (we only increase ℵⁿ, post increase ridging will adjust h)
+    # └── ℵⁿ > 0  -> ice is growing (we increase both ℵ and h based on ℵⁿ)
+    #
+    # - ∂t_V < 0 : the ice is melting * tricky case to handle *
+    # ├── ℵⁿ == 0 -> not possible! (there is no ice to begin with)
+    # ├── h > hᶜ  -> ice is melting (we decrease both ℵ and h based on ℵⁿ)
+    # └── h ≤ hᶜ  -> unconsolidated ice is melting (we only decrease ℵⁿ)
+
+    freezing     = ∂t_V > 0  
+    consolidated = hⁿ ≥ hᶜ
+    open_ocean   = ℵⁿ == 0
+
+    # Freezing and melting cases:
+    hᶠ = hⁿ + Δt * ∂t_V * ℵⁿ * !open_ocean
+    hᵐ = hⁿ + Δt * ∂t_V * ℵⁿ * consolidated
+    hᵐ = max(hᵐ, zero(hᵐ))
+    h⁺ = ifelse(freezing, hᶠ, hᵐ)
+
+    # There is also a very particular case when the ice is nucleating corresponding
+    # h⁺ == 0 and freezing. In this case, we set h = hᶜ and advance ℵ accordingly
+    h⁺ = ifelse(freezing & (h⁺ == 0), hᶜ, h⁺)
+    ℵ⁺ = Vⁿ⁺¹ / h⁺
     
-    # Update ice thickness and concentration
-    ℵ⁺ = ℵⁿ + Δt * (∂t_ℵᶠ + ∂t_ℵᵐ)
-    h⁺ = Vⁿ⁺¹ / ℵ⁺
-
-    # Treat patological cases
-    ℵ⁺ = max(zero(ℵ⁺), ℵ⁺)
-    h⁺ = ifelse(ℵ⁺ ≤ 0, zero(h⁺), h⁺)
-
     # No volume change
     ℵ⁺ = ifelse(∂t_V == 0, ℵⁿ, ℵ⁺)
     h⁺ = ifelse(∂t_V == 0, hⁿ, h⁺)
-    ℵ⁺ = ifelse(h⁺ == 0, zero(ℵ⁺), ℵ⁺) # reset the concentration if there is no sea-ice
 
     # Ridging caused by the thermodynamic step
     @inbounds ice_concentration[i, j, 1] = ifelse(ℵ⁺ > 1, one(ℵ⁺), ℵ⁺)


### PR DESCRIPTION
This PR adds two utility functions to compute the total momentum stress and fix a NaN that could occur when `h == 0` and the volume change is zero by multiplying by a `false` instead of a zero