### PR TITLE
Change momentum stress convention

### DIFF
--- a/src/SeaIceMomentumEquations/momentum_tendencies_kernel_functions.jl
+++ b/src/SeaIceMomentumEquations/momentum_tendencies_kernel_functions.jl
@@ -21,7 +21,7 @@ using Oceananigans.Coriolis: y_f_cross_U, x_f_cross_U
      mᵢ = ℑxᶠᵃᵃ(i, j, 1, grid, ice_mass, h, ℵ, ρ) 
 
      Gᵁ = ( - x_f_cross_U(i, j, 1, grid, coriolis, U) 
-            + explicit_τx(i, j, 1, grid, u_top_stress, clock, model_fields) / mᵢ * ℵᵢ
+            - explicit_τx(i, j, 1, grid, u_top_stress, clock, model_fields) / mᵢ * ℵᵢ
             + explicit_τx(i, j, 1, grid, u_bottom_stress, clock, model_fields) / mᵢ * ℵᵢ
             + ∂ⱼ_σ₁ⱼ(i, j, 1, grid, rheology, clock, model_fields) / mᵢ
             + immersed_∂ⱼ_σ₁ⱼ(i, j, 1, grid, u_immersed_bc, rheology, clock, model_fields) / mᵢ
@@ -53,7 +53,7 @@ end
      mᵢ = ℑyᵃᶠᵃ(i, j, 1, grid, ice_mass, h, ℵ, ρ) 
 
      Gⱽ = ( - y_f_cross_U(i, j, 1, grid, coriolis, U)
-            + explicit_τy(i, j, 1, grid, v_top_stress, clock, model_fields) / mᵢ * ℵᵢ
+            - explicit_τy(i, j, 1, grid, v_top_stress, clock, model_fields) / mᵢ * ℵᵢ
             + explicit_τy(i, j, 1, grid, v_bottom_stress, clock, model_fields) / mᵢ * ℵᵢ
             + ∂ⱼ_σ₂ⱼ(i, j, 1, grid, rheology, clock, model_fields) / mᵢ 
             + immersed_∂ⱼ_σ₂ⱼ(i, j, 1, grid, v_immersed_bc, rheology, clock, model_fields) / mᵢ

--- a/src/SeaIceMomentumEquations/split_explicit_momentum_equations.jl
+++ b/src/SeaIceMomentumEquations/split_explicit_momentum_equations.jl
@@ -122,7 +122,7 @@ end
    
     # Implicit part of the stress that depends linearly on the velocity
     τuᵢ = ( implicit_τx_coefficient(i, j, 1, grid, u_bottom_stress, clock, model_fields) 
-          + implicit_τx_coefficient(i, j, 1, grid, u_top_stress, clock, model_fields)) / mᵢ * ℵᵢ 
+          - implicit_τx_coefficient(i, j, 1, grid, u_top_stress, clock, model_fields)) / mᵢ * ℵᵢ 
 
     τuᵢ = ifelse(mᵢ ≤ 0, zero(grid), τuᵢ)
     uᴰ  = @inbounds (u[i, j, 1] + Δτ * Gu) / (1 + Δτ * τuᵢ) # dynamical velocity 
@@ -152,7 +152,7 @@ end
 
     # Implicit part of the stress that depends linearly on the velocity
     τvᵢ = ( implicit_τy_coefficient(i, j, 1, grid, v_bottom_stress, clock, model_fields)
-          + implicit_τy_coefficient(i, j, 1, grid, v_top_stress, clock, model_fields)) / mᵢ * ℵᵢ 
+          - implicit_τy_coefficient(i, j, 1, grid, v_top_stress, clock, model_fields)) / mᵢ * ℵᵢ 
 
     τvᵢ = ifelse(mᵢ ≤ 0, zero(grid), τvᵢ)
 


### PR DESCRIPTION
This PR changes the convention of the top momentum stresses to be positive upwards (momentum flux slowing the sea ice or accelerating the sea ice in the negative direction).

In this way, the convention is the same as for Oceananigans.