### PR TITLE
Last index for `SeaIceMomentumEquations`

### DIFF
--- a/src/Rheologies/elasto_visco_plastic_rheology.jl
+++ b/src/Rheologies/elasto_visco_plastic_rheology.jl
@@ -175,14 +175,13 @@ function compute_stresses!(model, dynamics, rheology::ElastoViscoPlasticRheology
     return nothing
 end
 
-@inline strain_rate_xx(i, j, k, grid, u, v) = δxᶜᵃᵃ(i, j, k, grid, Δy_qᶠᶜᶜ, u) / Azᶜᶜᶜ(i, j, k, grid)
-@inline strain_rate_yy(i, j, k, grid, u, v) = δyᵃᶜᵃ(i, j, k, grid, Δx_qᶜᶠᶜ, v) / Azᶜᶜᶜ(i, j, k, grid)
+@inline strain_rate_xx(i, j, k, grid, u, v) =  δxᶜᵃᵃ(i, j, k, grid, Δy_qᶠᶜᶜ, u) / Azᶜᶜᶜ(i, j, k, grid)
+@inline strain_rate_yy(i, j, k, grid, u, v) =  δyᵃᶜᵃ(i, j, k, grid, Δx_qᶜᶠᶜ, v) / Azᶜᶜᶜ(i, j, k, grid)
 @inline strain_rate_xy(i, j, k, grid, u, v) = (δxᶠᵃᵃ(i, j, k, grid, Δy_qᶜᶠᶜ, v) + δyᵃᶠᵃ(i, j, k, grid, Δx_qᶠᶜᶜ, u)) / Azᶠᶠᶜ(i, j, k, grid) / 2
 
 @kernel function _compute_evp_viscosities!(fields, grid, rheology, u, v)
     i, j = @index(Global, NTuple)
-
-    P = fields.P
+    kᴺ   = size(grid, 3)
 
     e⁻² = rheology.yield_curve_eccentricity^(-2)
     Δm  = rheology.minimum_plastic_stress
@@ -191,11 +190,11 @@ end
     P = fields.P
 
     # Strain rates
-    ϵ̇₁₁ = strain_rate_xx(i, j, 1, grid, u, v) 
-    ϵ̇₂₂ = strain_rate_yy(i, j, 1, grid, u, v) 
+    ϵ̇₁₁ = strain_rate_xx(i, j, kᴺ, grid, u, v) 
+    ϵ̇₂₂ = strain_rate_yy(i, j, kᴺ, grid, u, v) 
 
     # Center - Center variables:
-    ϵ̇₁₂ᶜᶜᶜ = ℑxyᶜᶜᵃ(i, j, 1, grid, strain_rate_xy, u, v)
+    ϵ̇₁₂ᶜᶜᶜ = ℑxyᶜᶜᵃ(i, j, kᴺ, grid, strain_rate_xy, u, v)
 
     # Ice divergence 
     δ = ϵ̇₁₁ + ϵ̇₂₂
@@ -218,6 +217,7 @@ end
 # following the αEVP formulation of Kimmritz et al (2016).
 @kernel function _compute_evp_stresses!(fields, grid, rheology, u, v, h, ℵ, ρᵢ, Δt)
     i, j = @index(Global, NTuple)
+    kᴺ   = size(grid, 3)
 
     e⁻² = rheology.yield_curve_eccentricity^(-2)
     Δm  = rheology.minimum_plastic_stress
@@ -230,9 +230,9 @@ end
     α   = fields.α
     
     # Strain rates
-    ϵ̇₁₁ = strain_rate_xx(i, j, 1, grid, u, v) 
-    ϵ̇₂₂ = strain_rate_yy(i, j, 1, grid, u, v) 
-    ϵ̇₁₂ = strain_rate_xy(i, j, 1, grid, u, v)
+    ϵ̇₁₁ = strain_rate_xx(i, j, kᴺ, grid, u, v) 
+    ϵ̇₂₂ = strain_rate_yy(i, j, kᴺ, grid, u, v) 
+    ϵ̇₁₂ = strain_rate_xy(i, j, kᴺ, grid, u, v)
 
     Pᶜᶜᶜ = @inbounds fields.P[i, j, 1]
     ζᶜᶜᶜ = @inbounds fields.ζ[i, j, 1]

--- a/src/SeaIceMomentumEquations/explicit_momentum_equations.jl
+++ b/src/SeaIceMomentumEquations/explicit_momentum_equations.jl
@@ -38,25 +38,26 @@ end
                                    ocean_velocities, minimum_mass, minimum_concentration, clock, fields)
 
     i, j = @index(Global, NTuple)
-    
-    ℵᶠᶜ = ℑxᶠᵃᵃ(i, j, 1, grid, fields.ℵ)
-    ℵᶜᶠ = ℑyᵃᶠᵃ(i, j, 1, grid, fields.ℵ)
-    mᶠᶜ = ℑxᶠᵃᵃ(i, j, 1, grid, ice_mass, fields.h, fields.ℵ, fields.ρ)
-    mᶜᶠ = ℑyᵃᶠᵃ(i, j, 1, grid, ice_mass, fields.h, fields.ℵ, fields.ρ)
+    kᴺ   = size(grid, 3)
+
+    ℵᶠᶜ = ℑxᶠᵃᵃ(i, j, kᴺ, grid, fields.ℵ)
+    ℵᶜᶠ = ℑyᵃᶠᵃ(i, j, kᴺ, grid, fields.ℵ)
+    mᶠᶜ = ℑxᶠᵃᵃ(i, j, kᴺ, grid, ice_mass, fields.h, fields.ℵ, fields.ρ)
+    mᶜᶠ = ℑyᵃᶠᵃ(i, j, kᴺ, grid, ice_mass, fields.h, fields.ℵ, fields.ρ)
 
    # Implicit part of the stress that depends linearly on the velocity
-   τuᵢ = ( implicit_τx_coefficient(i, j, 1, grid, bottom_stress, clock, fields) 
-         + implicit_τx_coefficient(i, j, 1, grid, top_stress,    clock, fields)) / mᶠᶜ * ℵᶠᶜ 
+   τuᵢ = ( implicit_τx_coefficient(i, j, kᴺ, grid, bottom_stress, clock, fields) 
+         - implicit_τx_coefficient(i, j, kᴺ, grid, top_stress,    clock, fields)) / mᶠᶜ * ℵᶠᶜ 
    
-   τvᵢ = ( implicit_τy_coefficient(i, j, 1, grid, bottom_stress, clock, fields) 
-         + implicit_τy_coefficient(i, j, 1, grid, top_stress,    clock, fields)) / mᶜᶠ * ℵᶜᶠ 
+   τvᵢ = ( implicit_τy_coefficient(i, j, kᴺ, grid, bottom_stress, clock, fields) 
+         - implicit_τy_coefficient(i, j, kᴺ, grid, top_stress,    clock, fields)) / mᶜᶠ * ℵᶜᶠ 
 
     @inbounds begin
         uᴰ = (u[i, j, 1] + Δt * Gⁿ.u[i, j, 1]) / (1 + Δt * τuᵢ)
         vᴰ = (v[i, j, 1] + Δt * Gⁿ.v[i, j, 1]) / (1 + Δt * τvᵢ)
 
-        uᶠ = free_drift_u(i, j, 1, grid, ocean_velocities)
-        vᶠ = free_drift_v(i, j, 1, grid, ocean_velocities)
+        uᶠ = free_drift_u(i, j, kᴺ, grid, ocean_velocities)
+        vᶠ = free_drift_v(i, j, kᴺ, grid, ocean_velocities)
 
         sea_ice = (mᶠᶜ ≥ minimum_mass) & (ℵᶠᶜ ≥ minimum_concentration)
         u[i, j, 1] = ifelse(sea_ice, uᴰ, uᶠ)

--- a/src/SeaIceMomentumEquations/momentum_tendencies_kernel_functions.jl
+++ b/src/SeaIceMomentumEquations/momentum_tendencies_kernel_functions.jl
@@ -11,21 +11,23 @@ using Oceananigans.Coriolis: y_f_cross_U, x_f_cross_U
                                      u_bottom_stress,
                                      u_forcing)
 
+     kᴺ = size(grid, 3)
+
      h = model_fields.h
      ℵ = model_fields.ℵ
      ρ = model_fields.ρ
      U = (u = model_fields.u, v = model_fields.v)
 
      # Ice mass (per unit area) interpolated on u points
-     ℵᵢ = ℑxᶠᵃᵃ(i, j, 1, grid, ℵ)
-     mᵢ = ℑxᶠᵃᵃ(i, j, 1, grid, ice_mass, h, ℵ, ρ) 
+     ℵᵢ = ℑxᶠᵃᵃ(i, j, kᴺ, grid, ℵ)
+     mᵢ = ℑxᶠᵃᵃ(i, j, kᴺ, grid, ice_mass, h, ℵ, ρ) 
 
-     Gᵁ = ( - x_f_cross_U(i, j, 1, grid, coriolis, U) 
-            + explicit_τx(i, j, 1, grid, u_top_stress, clock, model_fields) / mᵢ * ℵᵢ
-            + explicit_τx(i, j, 1, grid, u_bottom_stress, clock, model_fields) / mᵢ * ℵᵢ
-            + ∂ⱼ_σ₁ⱼ(i, j, 1, grid, rheology, clock, model_fields) / mᵢ
-            + immersed_∂ⱼ_σ₁ⱼ(i, j, 1, grid, u_immersed_bc, rheology, clock, model_fields) / mᵢ
-            + sum_of_forcing_u(i, j, 1, grid, rheology, u_forcing, model_fields, Δt))  # sum of user defined forcing and possibly other forcing terms that are rheology-dependent 
+     Gᵁ = ( - x_f_cross_U(i, j, kᴺ, grid, coriolis, U) 
+            + explicit_τx(i, j, kᴺ, grid, u_top_stress, clock, model_fields) / mᵢ * ℵᵢ
+            + explicit_τx(i, j, kᴺ, grid, u_bottom_stress, clock, model_fields) / mᵢ * ℵᵢ
+            + ∂ⱼ_σ₁ⱼ(i, j, kᴺ, grid, rheology, clock, model_fields) / mᵢ
+            + immersed_∂ⱼ_σ₁ⱼ(i, j, kᴺ, grid, u_immersed_bc, rheology, clock, model_fields) / mᵢ
+            + sum_of_forcing_u(i, j, kᴺ, grid, rheology, u_forcing, model_fields, Δt))  # sum of user defined forcing and possibly other forcing terms that are rheology-dependent 
 
      Gᵁ = ifelse(mᵢ ≤ 0, zero(grid), Gᵁ)
 
@@ -49,15 +51,15 @@ end
      U = (u = model_fields.u, v = model_fields.v)
 
      # Ice mass (per unit area) interpolated on v points
-     ℵᵢ = ℑyᵃᶠᵃ(i, j, 1, grid, ℵ)
-     mᵢ = ℑyᵃᶠᵃ(i, j, 1, grid, ice_mass, h, ℵ, ρ) 
+     ℵᵢ = ℑyᵃᶠᵃ(i, j, kᴺ, grid, ℵ)
+     mᵢ = ℑyᵃᶠᵃ(i, j, kᴺ, grid, ice_mass, h, ℵ, ρ) 
 
-     Gⱽ = ( - y_f_cross_U(i, j, 1, grid, coriolis, U)
-            + explicit_τy(i, j, 1, grid, v_top_stress, clock, model_fields) / mᵢ * ℵᵢ
-            + explicit_τy(i, j, 1, grid, v_bottom_stress, clock, model_fields) / mᵢ * ℵᵢ
-            + ∂ⱼ_σ₂ⱼ(i, j, 1, grid, rheology, clock, model_fields) / mᵢ 
-            + immersed_∂ⱼ_σ₂ⱼ(i, j, 1, grid, v_immersed_bc, rheology, clock, model_fields) / mᵢ
-            + sum_of_forcing_v(i, j, 1, grid, rheology, v_forcing, model_fields, Δt)) # sum of user defined forcing and possibly other forcing terms that are rheology-dependent 
+     Gⱽ = ( - y_f_cross_U(i, j, kᴺ, grid, coriolis, U)
+            + explicit_τy(i, j, kᴺ, grid, v_top_stress, clock, model_fields) / mᵢ * ℵᵢ
+            + explicit_τy(i, j, kᴺ, grid, v_bottom_stress, clock, model_fields) / mᵢ * ℵᵢ
+            + ∂ⱼ_σ₂ⱼ(i, j, kᴺ, grid, rheology, clock, model_fields) / mᵢ 
+            + immersed_∂ⱼ_σ₂ⱼ(i, j, kᴺ, grid, v_immersed_bc, rheology, clock, model_fields) / mᵢ
+            + sum_of_forcing_v(i, j, kᴺ, grid, rheology, v_forcing, model_fields, Δt)) # sum of user defined forcing and possibly other forcing terms that are rheology-dependent 
 
      Gⱽ = ifelse(mᵢ ≤ 0, zero(grid), Gⱽ)
 

--- a/src/SeaIceMomentumEquations/momentum_tendencies_kernel_functions.jl
+++ b/src/SeaIceMomentumEquations/momentum_tendencies_kernel_functions.jl
@@ -12,11 +12,10 @@ using Oceananigans.Coriolis: y_f_cross_U, x_f_cross_U
                                      u_forcing)
 
      kᴺ = size(grid, 3)
-
-     h = model_fields.h
-     ℵ = model_fields.ℵ
-     ρ = model_fields.ρ
-     U = (u = model_fields.u, v = model_fields.v)
+     h  = model_fields.h
+     ℵ  = model_fields.ℵ
+     ρ  = model_fields.ρ
+     U  = (u = model_fields.u, v = model_fields.v)
 
      # Ice mass (per unit area) interpolated on u points
      ℵᵢ = ℑxᶠᵃᵃ(i, j, kᴺ, grid, ℵ)
@@ -45,6 +44,7 @@ end
                                      v_bottom_stress,
                                      v_forcing)
 
+     kᴺ = size(grid, 3)
      h = model_fields.h
      ℵ = model_fields.ℵ
      ρ = model_fields.ρ

--- a/src/SeaIceMomentumEquations/split_explicit_momentum_equations.jl
+++ b/src/SeaIceMomentumEquations/split_explicit_momentum_equations.jl
@@ -126,7 +126,7 @@ end
           - implicit_τx_coefficient(i, j, kᴺ, grid, u_top_stress, clock, model_fields)) / mᵢ * ℵᵢ 
 
     τuᵢ = ifelse(mᵢ ≤ 0, zero(grid), τuᵢ)
-    uᴰ  = @inbounds (u[i, j, kᴺ] + Δτ * Gu) / (1 + Δτ * τuᵢ) # dynamical velocity 
+    uᴰ  = @inbounds (u[i, j, 1] + Δτ * Gu) / (1 + Δτ * τuᵢ) # dynamical velocity 
     uᶠ  = free_drift_u(i, j, kᴺ, grid, ocean_velocities) # free drift velocity
 
     # If the ice mass or the ice concentration are below a certain threshold, 
@@ -158,7 +158,7 @@ end
 
     τvᵢ = ifelse(mᵢ ≤ 0, zero(grid), τvᵢ)
 
-    vᴰ = @inbounds (v[i, j, kᴺ] + Δτ * Gv) / (1 + Δτ * τvᵢ)# dynamical velocity 
+    vᴰ = @inbounds (v[i, j, 1] + Δτ * Gv) / (1 + Δτ * τvᵢ)# dynamical velocity 
     vᶠ = free_drift_v(i, j, kᴺ, grid, ocean_velocities) # free drift velocity
 
     # If the ice mass or the ice concentration are below a certain threshold, 

--- a/src/SeaIceMomentumEquations/split_explicit_momentum_equations.jl
+++ b/src/SeaIceMomentumEquations/split_explicit_momentum_equations.jl
@@ -113,20 +113,20 @@ end
                                    u_immersed_bc, u_top_stress, u_bottom_stress, u_forcing)
 
     i, j = @index(Global, NTuple)
-
-    mᵢ = ℑxᶠᵃᵃ(i, j, 1, grid, ice_mass, model_fields.h, model_fields.ℵ, model_fields.ρ)
-    ℵᵢ = ℑxᶠᵃᵃ(i, j, 1, grid, model_fields.ℵ)
+    kᴺ = size(grid, 3) 
+    mᵢ = ℑxᶠᵃᵃ(i, j, kᴺ, grid, ice_mass, model_fields.h, model_fields.ℵ, model_fields.ρ)
+    ℵᵢ = ℑxᶠᵃᵃ(i, j, kᴺ, grid, model_fields.ℵ)
 
     Δτ = compute_substep_Δtᶠᶜᶜ(i, j, grid, Δt, rheology, substeps, model_fields) 
     Gu = u_velocity_tendency(i, j, grid, Δτ, rheology, model_fields, clock, coriolis, u_immersed_bc, u_top_stress, u_bottom_stress, u_forcing)
    
     # Implicit part of the stress that depends linearly on the velocity
-    τuᵢ = ( implicit_τx_coefficient(i, j, 1, grid, u_bottom_stress, clock, model_fields) 
-          + implicit_τx_coefficient(i, j, 1, grid, u_top_stress, clock, model_fields)) / mᵢ * ℵᵢ 
+    τuᵢ = ( implicit_τx_coefficient(i, j, kᴺ, grid, u_bottom_stress, clock, model_fields) 
+          + implicit_τx_coefficient(i, j, kᴺ, grid, u_top_stress, clock, model_fields)) / mᵢ * ℵᵢ 
 
     τuᵢ = ifelse(mᵢ ≤ 0, zero(grid), τuᵢ)
-    uᴰ  = @inbounds (u[i, j, 1] + Δτ * Gu) / (1 + Δτ * τuᵢ) # dynamical velocity 
-    uᶠ  = free_drift_u(i, j, 1, grid, ocean_velocities) # free drift velocity
+    uᴰ  = @inbounds (u[i, j, kᴺ] + Δτ * Gu) / (1 + Δτ * τuᵢ) # dynamical velocity 
+    uᶠ  = free_drift_u(i, j, kᴺ, grid, ocean_velocities) # free drift velocity
 
     # If the ice mass or the ice concentration are below a certain threshold, 
     # the sea ice velocity is set to the free drift velocity
@@ -144,20 +144,20 @@ end
 
     i, j = @index(Global, NTuple)
     
-    mᵢ = ℑyᵃᶠᵃ(i, j, 1, grid, ice_mass, model_fields.h, model_fields.ℵ, model_fields.ρ)
-    ℵᵢ = ℑyᵃᶠᵃ(i, j, 1, grid, model_fields.ℵ)
+    mᵢ = ℑyᵃᶠᵃ(i, j, kᴺ, grid, ice_mass, model_fields.h, model_fields.ℵ, model_fields.ρ)
+    ℵᵢ = ℑyᵃᶠᵃ(i, j, kᴺ, grid, model_fields.ℵ)
     
     Δτ = compute_substep_Δtᶜᶠᶜ(i, j, grid, Δt, rheology, substeps, model_fields) 
     Gv = v_velocity_tendency(i, j, grid, Δτ, rheology, model_fields, clock, coriolis, v_immersed_bc, v_top_stress, v_bottom_stress, v_forcing)
 
     # Implicit part of the stress that depends linearly on the velocity
-    τvᵢ = ( implicit_τy_coefficient(i, j, 1, grid, v_bottom_stress, clock, model_fields)
-          + implicit_τy_coefficient(i, j, 1, grid, v_top_stress, clock, model_fields)) / mᵢ * ℵᵢ 
+    τvᵢ = ( implicit_τy_coefficient(i, j, kᴺ, grid, v_bottom_stress, clock, model_fields)
+          + implicit_τy_coefficient(i, j, kᴺ, grid, v_top_stress, clock, model_fields)) / mᵢ * ℵᵢ 
 
     τvᵢ = ifelse(mᵢ ≤ 0, zero(grid), τvᵢ)
 
-    vᴰ = @inbounds (v[i, j, 1] + Δτ * Gv) / (1 + Δτ * τvᵢ)# dynamical velocity 
-    vᶠ = free_drift_v(i, j, 1, grid, ocean_velocities) # free drift velocity
+    vᴰ = @inbounds (v[i, j, kᴺ] + Δτ * Gv) / (1 + Δτ * τvᵢ)# dynamical velocity 
+    vᶠ = free_drift_v(i, j, kᴺ, grid, ocean_velocities) # free drift velocity
 
     # If the ice mass or the ice concentration are below a certain threshold, 
     # the sea ice velocity is set to the free drift velocity

--- a/src/SeaIceMomentumEquations/split_explicit_momentum_equations.jl
+++ b/src/SeaIceMomentumEquations/split_explicit_momentum_equations.jl
@@ -113,7 +113,8 @@ end
                                    u_immersed_bc, u_top_stress, u_bottom_stress, u_forcing)
 
     i, j = @index(Global, NTuple)
-    kᴺ = size(grid, 3) 
+    kᴺ   = size(grid, 3) 
+
     mᵢ = ℑxᶠᵃᵃ(i, j, kᴺ, grid, ice_mass, model_fields.h, model_fields.ℵ, model_fields.ρ)
     ℵᵢ = ℑxᶠᵃᵃ(i, j, kᴺ, grid, model_fields.ℵ)
 
@@ -143,7 +144,8 @@ end
                                    v_immersed_bc, v_top_stress, v_bottom_stress, v_forcing)
 
     i, j = @index(Global, NTuple)
-    
+    kᴺ   = size(grid, 3) 
+
     mᵢ = ℑyᵃᶠᵃ(i, j, kᴺ, grid, ice_mass, model_fields.h, model_fields.ℵ, model_fields.ρ)
     ℵᵢ = ℑyᵃᶠᵃ(i, j, kᴺ, grid, model_fields.ℵ)
     

--- a/src/SeaIceThermodynamics/slab_heat_and_tracer_fluxes.jl
+++ b/src/SeaIceThermodynamics/slab_heat_and_tracer_fluxes.jl
@@ -14,7 +14,7 @@ ConductiveFlux(FT::DataType=Float64; conductivity) = ConductiveFlux(convert(FT, 
     Tb = bottom_temperature
     h = ice_thickness
 
-    return ifelse(h <= 0, zero(h), - k * (Tu - Tb) / h)
+    return ifelse(h ≤ 0, zero(h), - k * (Tu - Tb) / h)
 end
 
 @inline function slab_internal_heat_flux(i, j, grid,

--- a/src/SeaIceThermodynamics/thermodynamic_time_step.jl
+++ b/src/SeaIceThermodynamics/thermodynamic_time_step.jl
@@ -46,7 +46,7 @@ end
                                                 model_fields)
 
     i, j = @index(Global, NTuple)
-    
+     
     @inbounds hⁿ = ice_thickness[i, j, 1]
     @inbounds ℵⁿ = ice_concentration[i, j, 1]
     @inbounds hᶜ = ice_consolidation_thickness[i, j, 1]

--- a/src/sea_ice_model.jl
+++ b/src/sea_ice_model.jl
@@ -46,7 +46,7 @@ function SeaIceModel(grid;
                      advection                   = nothing,
                      tracers                     = (),
                      boundary_conditions         = NamedTuple(),
-                     ice_thermodynamics              = SlabSeaIceThermodynamics(grid),
+                     ice_thermodynamics          = SlabSeaIceThermodynamics(grid),
                      dynamics                    = nothing,
                      forcing                     = NamedTuple())
 

--- a/src/tracer_tendency_kernel_functions.jl
+++ b/src/tracer_tendency_kernel_functions.jl
@@ -33,10 +33,11 @@ end
                                                      tracers)
 
     i, j = @index(Global, NTuple)
-    
+    kᴺ   = size(grid, 3) # Assumption! The sea ice is located at the _top_ of the grid
+ 
     @inbounds begin
-        Gⁿ.h[i, j, 1] = - horizontal_div_Uc(i, j, 1, grid, advection, velocities, ice_thickness)
-        Gⁿ.ℵ[i, j, 1] = - horizontal_div_Uc(i, j, 1, grid, advection, velocities, ice_concentration)
+        Gⁿ.h[i, j, 1] = - horizontal_div_Uc(i, j, kᴺ, grid, advection, velocities, ice_thickness)
+        Gⁿ.ℵ[i, j, 1] = - horizontal_div_Uc(i, j, kᴺ, grid, advection, velocities, ice_concentration)
 
         # for (n, θ) in enumerate(tracers)
         #     @inbounds Gⁿ[n] = - horizontal_div_Uc(i, j, 1, grid, advection, velocities, θ)


### PR DESCRIPTION
Sea ice dynamics are two-dimensional, if the grid is also `Flat` in the vertical there is no problem.
If the grid is not `Flat`, we need to evaluate tendencies either at `k=1` or `k=grid.Nz`.

To allow running the sea ice on the ocean grid (where it is more logical it should live and also the convention of ClimaOcean...), this PR switches the evaluation of tendencies at `k=grid.Nz` rather than `k=1`. 

Note that this affects only immersed boundary grids where we need to evaluate immersed terms. 
For all other grids there is no influence of the k index as all fields involved in dynamics computations are `Nothing` in the vertical