### PR TITLE
Compute salinity for the bottom boundary conditions at the top of the grid

### DIFF
--- a/src/SeaIceThermodynamics/HeatBoundaryConditions/bottom_heat_boundary_conditions.jl
+++ b/src/SeaIceThermodynamics/HeatBoundaryConditions/bottom_heat_boundary_conditions.jl
@@ -34,7 +34,8 @@ IceWaterThermalEquilibrium(; salinity=0) = IceWaterThermalEquilibrium(salinity)
 @inline bottom_temperature(i, j, grid, bc::PrescribedTemperature{<:Number}, args...) = bc.temperature
 
 @inline function bottom_temperature(i, j, grid, bc::IceWaterThermalEquilibrium, liquidus)
-    Sₒ = get_tracer(i, j, 1, grid, bc.salinity)
+    kᴺ = size(grid, 3)
+    Sₒ = get_tracer(i, j, kᴺ, grid, bc.salinity)
     return melting_temperature(liquidus, Sₒ)
 end
 


### PR DESCRIPTION
Supposedly, this is the salinity of the surface of the ocean. Given the convention that a slab sea ice is at the top of the grid, we need to compute the salinity at `size(grid, 3)` instead of `1`