### PR TITLE
Store a thermodynamic tendency

### DIFF
--- a/src/SeaIceThermodynamics/slab_sea_ice_thermodynamics.jl
+++ b/src/SeaIceThermodynamics/slab_sea_ice_thermodynamics.jl
@@ -2,11 +2,12 @@ import Oceananigans: fields
 
 struct ProportionalEvolution end
 
-struct SlabSeaIceThermodynamics{ST, HBC, CF, P, CE}
+struct SlabSeaIceThermodynamics{ST, HBC, CF, GT, P, CE}
     top_surface_temperature :: ST
     heat_boundary_conditions :: HBC
     # Internal flux
     internal_heat_flux :: CF
+    thermodynamic_tendency :: GT
     # Melting and freezing stuff
     phase_transitions :: P
     # Rules to evolve concentration
@@ -17,6 +18,7 @@ Adapt.adapt_structure(to, t::SlabSeaIceThermodynamics) =
     SlabSeaIceThermodynamics(Adapt.adapt(to, t.top_surface_temperature),
                              Adapt.adapt(to, t.heat_boundary_conditions),
                              Adapt.adapt(to, t.internal_heat_flux),
+                             Adapt.adapt(to, t.thermodynamic_tendency),
                              Adapt.adapt(to, t.phase_transitions),
                              Adapt.adapt(to, t.concentration_evolution))
 
@@ -69,12 +71,14 @@ function SlabSeaIceThermodynamics(grid;
         top_surface_temperature = Field{Center, Center, Nothing}(grid)
     end
 
+    thermodynamic_tendency = Field{Center, Center, Nothing}(grid)
     heat_boundary_conditions = (top = top_heat_boundary_condition,
                                 bottom = bottom_heat_boundary_condition)
 
     return SlabSeaIceThermodynamics(top_surface_temperature,
                                     heat_boundary_conditions,
                                     internal_heat_flux_function,
+                                    thermodynamic_tendency,
                                     phase_transitions,
                                     concentration_evolution)
 end

--- a/src/SeaIceThermodynamics/thermodynamic_time_step.jl
+++ b/src/SeaIceThermodynamics/thermodynamic_time_step.jl
@@ -47,6 +47,7 @@ end
 
     i, j = @index(Global, NTuple)
      
+    Gⁿ = ice_thermodynamics.thermodynamic_tendency
     @inbounds hⁿ = ice_thickness[i, j, 1]
     @inbounds ℵⁿ = ice_concentration[i, j, 1]
     @inbounds hᶜ = ice_consolidation_thickness[i, j, 1]
@@ -72,6 +73,9 @@ end
     ∂t_V = (Vⁿ⁺¹ - hⁿ * ℵⁿ) / Δt
     ℵ⁺   = concentration_thermodynamic_step(ice_thermodynamics.concentration_evolution, ∂t_V, ℵⁿ, hⁿ, hᶜ, Δt)
     h⁺   = Vⁿ⁺¹ / ℵ⁺
+
+    # Save thermodynamic tendency for possible later use
+    @inbounds Gⁿ[i, j, 1] = ∂t_V
     
     # Treat pathological cases
     h⁺ = ifelse(ℵ⁺ ≤ 0, zero(h⁺), h⁺)


### PR DESCRIPTION
Needed for possible later use. One use case is computing the salt release (or uptake) in the ocean.
An additional positive outcome of this PR is removing the need for a `previous_thickness` in the `OceanSeaIceModel` of `ClimaOcean`, which was a bit out of place.