### PR TITLE
Changing the default free drift

### DIFF
--- a/src/SeaIceDynamics/sea_ice_momentum_equations.jl
+++ b/src/SeaIceDynamics/sea_ice_momentum_equations.jl
@@ -20,9 +20,9 @@ struct ExplicitSolver end
                            coriolis = nothing,
                            rheology = ElastoViscoPlasticRheology(eltype(grid)),
                            auxiliary_fields = NamedTuple(),
-                           top_momentum_stress    = (u=nothing, v=nothing),
-                           bottom_momentum_stress = (u=nothing, v=nothing),
-                           free_drift = StressBalanceFreeDrift(; top_momentum_stress, bottom_momentum_stress),
+                           top_momentum_stress    = nothing,
+                           bottom_momentum_stress = nothing,
+                           free_drift = nothing,
                            solver = SplitExplicitSolver(150),
                            minimum_concentration = 1e-3,
                            minimum_mass = 1.0)
@@ -61,7 +61,7 @@ function SeaIceMomentumEquation(grid;
                                 auxiliary_fields = NamedTuple(),
                                 top_momentum_stress    = nothing,
                                 bottom_momentum_stress = nothing,
-                                free_drift = StressBalanceFreeDrift(; top_momentum_stress, bottom_momentum_stress),
+                                free_drift = nothing,
                                 solver = SplitExplicitSolver(150),
                                 minimum_concentration = 1e-3,
                                 minimum_mass = 1.0)


### PR DESCRIPTION
The default stresses are `nothing`, so it is better to have a `nothing` free drift default