### PR TITLE
Reset thickness if the new concentration is zero

### DIFF
--- a/src/SeaIceThermodynamics/thermodynamic_time_step.jl
+++ b/src/SeaIceThermodynamics/thermodynamic_time_step.jl
@@ -79,7 +79,8 @@ end
     ℵ⁺ = ifelse(∂t_V == 0, ℵⁿ, ℵ⁺)     # No volume change
     h⁺ = ifelse(∂t_V == 0, hⁿ, h⁺)     # No volume change
     ℵ⁺ = ifelse(h⁺ == 0, zero(ℵ⁺), ℵ⁺) # reset the concentration if there is no sea-ice
-    
+    h⁺ = ifelse(ℵ⁺ == 0, zero(h⁺), h⁺) # reset the thickness if there is no sea-ice
+
     # Ridging caused by the thermodynamic step
     ℵⁿ⁺¹ = ifelse(ℵ⁺ > 1, one(ℵ⁺), ℵ⁺)
     hⁿ⁺¹ = ifelse(ℵ⁺ > 1,  h⁺ * ℵ⁺, h⁺)

--- a/src/sea_ice_model.jl
+++ b/src/sea_ice_model.jl
@@ -31,9 +31,9 @@ struct SeaIceModel{GR, TD, D, TS, CL, U, T, IT, IC, ID, CT, STF, A, F, Arch} <: 
     advection :: A
 end
 
-assumed_sea_ice_field_location(name) = name === :u  ? (Face, Center, Nothing) :
-                                       name === :v  ? (Center, Face, Nothing) :
-                                                      (Center, Center, Nothing)
+assumed_sea_ice_field_location(name) = name === :u  ? (Face(),   Center(), nothing) :
+                                       name === :v  ? (Center(), Face(),   nothing) :
+                                                      (Center(), Center(), nothing)
 
 function SeaIceModel(grid;
                      clock                       = Clock{eltype(grid)}(time = 0),

--- a/src/sea_ice_time_stepping.jl
+++ b/src/sea_ice_time_stepping.jl
@@ -68,6 +68,9 @@ end
         ℵ⁺ = max(zero(ℵ⁺), ℵ⁺) # Concentration cannot be negative, clip it up
         h⁺ = max(zero(h⁺), h⁺) # Thickness cannot be negative, clip it up
 
+        ℵ⁺ = ifelse(h⁺ == 0, zero(ℵ⁺), ℵ⁺) # reset the concentration if there is no sea-ice
+        h⁺ = ifelse(ℵ⁺ == 0, zero(h⁺), h⁺) # reset the thickness if there is no sea-ice
+
         # Ridging and rafting caused by the advection step
         V⁺ = h⁺ * ℵ⁺
         


### PR DESCRIPTION
On ClimaOcean, ice is building up with a zero concentration in regions that should not generate sea ice. This is because if concentration is zero, both the atmospheric flux is zero and the melt flux is zero, so ice can build up over time. 

This PR corrects this by resetting the thickness if the new concentration is identically zero (in main, we are resetting only the concentration if thickness is identically zero, but it should go both ways).