### PR TITLE
Fix NCDatasets extension for Julia 1.12

### DIFF
--- a/ext/ClimaSeaIceNCDatasetsExt.jl
+++ b/ext/ClimaSeaIceNCDatasetsExt.jl
@@ -28,16 +28,12 @@ default_sea_ice_attributes() = Dict(
     "ℵ" => Dict("long_name" => "Sea ice concentration.", "units" => "-")
 )
 
-function __init__()
-    OCNE = Base.get_extension(Oceananigans, :OceananigansNCDatasetsExt)
-    if !isnothing(OCNE)
-        @eval begin
-            function $OCNE.default_output_attributes(model::SeaIceModel)
-                velocity_attrs = default_horizontal_velocity_attributes(model.grid)
-                tracer_attrs = default_sea_ice_attributes()
-                return merge(velocity_attrs, tracer_attrs)
-            end
-        end
+OCNE = Base.get_extension(Oceananigans, :OceananigansNCDatasetsExt)
+if !isnothing(OCNE)
+    function OCNE.default_output_attributes(model::SeaIceModel)
+        velocity_attrs = default_horizontal_velocity_attributes(model.grid)
+        tracer_attrs = default_sea_ice_attributes()
+        return merge(velocity_attrs, tracer_attrs)
     end
 end
 


### PR DESCRIPTION
## Summary
- Move `default_output_attributes(::SeaIceModel)` method definition from `__init__()` with `@eval` to top-level extension scope
- Julia 1.12 rejects `eval` into a closed module during `__init__`, causing precompilation to fail with: *"Evaluation into the closed module `ClimaSeaIceNCDatasetsExt` breaks incremental compilation because the side effects will not be permanent."*
- The method is now defined at extension load time, which is both correct and compatible with Julia 1.12's stricter compilation model

## Test plan
- [x] Verified `Pkg.precompile()` succeeds on Julia 1.12 with this patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)