### PR TITLE
(0.5.0) Share phase_transitions and bulk densities at the model level

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ KernelAbstractions = "0.9"
 Oceananigans = "0.106, 0.107, 0.108"
 RootSolvers = "0.3, 0.4, 1.0"
 Roots = "2"
-SeawaterPolynomials = "0.3.4"
+SeawaterPolynomials = "0.3, 0.4"
 julia = "1.10"
 
 [extras]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -50,6 +50,7 @@ pages = [
 
     "Physics" => [
         "Thermodynamics" => "physics/thermodynamics.md",
+        "Layered snow + ice implementation" => "physics/layered_snow_ice_implementation.md",
         "Dynamics and Rheology" => "physics/dynamics_and_rheology.md",
     ],
 

--- a/docs/src/physics/layered_snow_ice_implementation.md
+++ b/docs/src/physics/layered_snow_ice_implementation.md
@@ -29,8 +29,8 @@ Two conventions coexist and must be treated consistently:
 The snow surface sits on the ice-covered fraction only, so the surface energy balance is a **per-ice** balance:
 
 ```math
-\\delta Q = \\frac{Qui}{\\aleph^n} - Qis, \\qquad
-Q_s = \\min\\left(\\max(0, -\\delta Q), \\frac{\\rho_s \\mathcal{L}_s h_s^n}{\\Delta t}\\right).
+\delta Q = \frac{Qui}{\aleph^n} - Qis, \qquad
+Q_s = \min\left(\max(0, -\delta Q), \frac{\rho_s \mathcal{L}_s h_s^n}{\Delta t}\right).
 ```
 
 `Qs` (positive when melting) is the per-ice latent power absorbed by snow melt, giving a thickness rate `Gs⁻ = Qs/(ρₛ ℒₛ)`.
@@ -44,35 +44,35 @@ would otherwise suppress the snow melt rate.
 The slab mass balance and the `ProportionalEvolution` concentration rule are both linear in the end-of-step concentration `ℵⁿ⁺¹`:
 
 ```math
-\\partial_t V = \\frac{(Qui + Q_s \\aleph^{n+1}) - Qbi}{\\rho_i \\mathcal{L}}  \\equiv \\alpha + \\beta\\, \\aleph^{n+1},
+\partial_t V = \frac{(Qui + Q_s \aleph^{n+1}) - Qbi}{\rho_i \mathcal{L}}  \equiv \alpha + \beta\, \aleph^{n+1},
 ```
 
 with
 
 ```math
-\\alpha = \\frac{Qui - Qbi}{\\rho_i \\mathcal{L}}, \\quad
-\\beta  = \\frac{Q_s}{\\rho_i \\mathcal{L}},
+\alpha = \frac{Qui - Qbi}{\rho_i \mathcal{L}}, \quad
+\beta  = \frac{Q_s}{\rho_i \mathcal{L}},
 ```
 
 and
 
 ```math
-\\aleph^{n+1} = \\aleph^n + \\Delta t\\, C\\, \\partial_t V,
+\aleph^{n+1} = \aleph^n + \Delta t\, C\, \partial_t V,
 ```
 
 with
 
 ```math
-C = \\begin{cases}
-\\frac{\\aleph^n}{2 h^n} & \\text{if } \\partial_t V < 0 \\ \\text{(melt)} \\\\
-\\frac{1 - \\aleph^n}{h^c} & \\text{if } \\partial_t V \\ge 0 \\ \\text{(freeze)}.
-\\end{cases}
+C = \begin{cases}
+\frac{\aleph^n}{2 h^n} & \text{if } \partial_t V < 0 \ \text{(melt)} \\
+\frac{1 - \aleph^n}{h^c} & \text{if } \partial_t V \ge 0 \ \text{(freeze)}.
+\end{cases}
 ```
 
 Defining `K = Δt · C`, the fixed point `ℵⁿ⁺¹ · (1 − K β) = ℵⁿ + K α` has the **closed-form solution**
 
 ```math
-\\boxed{\\aleph^{n+1} = \\frac{\\aleph^n + K \\alpha}{1 - K \\beta}}.
+\boxed{\aleph^{n+1} = \frac{\aleph^n + K \alpha}{1 - K \beta}}.
 ```
 
 ## Branch selection

--- a/docs/src/physics/layered_snow_ice_implementation.md
+++ b/docs/src/physics/layered_snow_ice_implementation.md
@@ -1,0 +1,113 @@
+# Layered snow + ice thermodynamics — implementation notes
+
+This page documents the snow-surface energy balance and the closed-form implicit solve for end-of-step ice concentration used by
+`_layered_thermodynamic_time_step!`. It assumes familiarity with the slab mass balance described in the Thermodynamics chapter.
+
+## Column geometry
+
+Each cell contains an ice-covered fraction `ℵ`; snow sits on the ice only. The prognostic variables are
+
+- `h`  — ice thickness on the ice-covered fraction (m, per-ice)
+- `ℵ`  — ice concentration (unitless, per-cell area fraction)
+- `hs` — snow thickness on the ice-covered fraction (m, per-ice)
+
+with the ice-volume invariant `V = h · ℵ` tracked per unit *cell* area. Snow volume per unit cell area is `hs · ℵ` and is conserved 
+across changes in `ℵ` by the kernel's `hs ← hs · ℵⁿ/ℵⁿ⁺¹` rescale.
+
+## Per-ice vs. per-cell fluxes
+
+Two conventions coexist and must be treated consistently:
+
+- `Qui` (top external heat flux), `Qbi` (bottom external heat flux) are delivered by the coupler **per unit cell area** (radiation and
+  turbulent fluxes × ℵ on the ice path, interface heat × ℵ on the ocean path).
+- `Qis` (column conductive flux `(Tb − Tu)/R`, `R = hs/ks + hi/ki`) is intrinsically **per unit ice area**: the thermal resistance only
+  applies where ice exists.
+- `Qii` (ice-only internal conductive flux) is similarly per-ice.
+
+## Snow-surface energy balance
+
+The snow surface sits on the ice-covered fraction only, so the surface energy balance is a **per-ice** balance:
+
+```math
+\\delta Q = \\frac{Qui}{\\aleph^n} - Qis, \\qquad
+Q_s = \\min\\left(\\max(0, -\\delta Q), \\frac{\\rho_s \\mathcal{L}_s h_s^n}{\\Delta t}\\right).
+```
+
+`Qs` (positive when melting) is the per-ice latent power absorbed by snow melt, giving a thickness rate `Gs⁻ = Qs/(ρₛ ℒₛ)`.
+
+The atmospheric flux `Qui` passed by the coupler is per-cell, so we divide by `ℵⁿ` before comparing with `Qis`. 
+When `ℵⁿ = 1` this reduces to the original formulation; when `ℵⁿ < 1` it avoids the spurious factor of `ℵⁿ` that 
+would otherwise suppress the snow melt rate.
+
+## Implicit concentration update
+
+The slab mass balance and the `ProportionalEvolution` concentration rule are both linear in the end-of-step concentration `ℵⁿ⁺¹`:
+
+```math
+\\partial_t V = \\frac{(Qui + Q_s \\aleph^{n+1}) - Qbi}{\\rho_i \\mathcal{L}}  \\equiv \\alpha + \\beta\\, \\aleph^{n+1},
+```
+
+with
+
+```math
+\\alpha = \\frac{Qui - Qbi}{\\rho_i \\mathcal{L}}, \\quad
+\\beta  = \\frac{Q_s}{\\rho_i \\mathcal{L}},
+```
+
+and
+
+```math
+\\aleph^{n+1} = \\aleph^n + \\Delta t\\, C\\, \\partial_t V,
+```
+
+with
+
+```math
+C = \\begin{cases}
+\\frac{\\aleph^n}{2 h^n} & \\text{if } \\partial_t V < 0 \\ \\text{(melt)} \\\\
+\\frac{1 - \\aleph^n}{h^c} & \\text{if } \\partial_t V \\ge 0 \\ \\text{(freeze)}.
+\\end{cases}
+```
+
+Defining `K = Δt · C`, the fixed point `ℵⁿ⁺¹ · (1 − K β) = ℵⁿ + K α` has the **closed-form solution**
+
+```math
+\\boxed{\\aleph^{n+1} = \\frac{\\aleph^n + K \\alpha}{1 - K \\beta}}.
+```
+
+## Branch selection
+
+The correct branch (melt vs. freeze) depends on the sign of `∂t_V` at the solution, which isn't known up front. The kernel computes *both*
+branches and picks the one where `sign(∂t_V(ℵⁿ⁺¹))` is consistent with the branch assumption:
+
+- if `α + β · ℵᵐ < 0`, use the melt-branch solution `ℵᵐ`
+- otherwise, use the freeze-branch solution `ℵᶠ`
+
+This is branchless (via `ifelse`) and correct at the `α ≈ 0` boundary where the first-guess sign could be misleading. On ocean scales
+`|K β| ≲ 10⁻⁶`, so the sign rarely flips between guess and solution; the test is defensive for the atypical case where atmospheric heating
+almost exactly cancels the column conductive flux.
+
+## NaN guards
+
+All divisions are protected:
+
+- `Qui / ℵⁿ`      → falls back to `0` if `ℵⁿ ≤ 0`
+- `ℵⁿ / (2 hⁿ)`   → falls back to `0` if `hⁿ ≤ 0`
+- `(1 − ℵⁿ) / hᶜ` → falls back to `0` if `hᶜ ≤ 0`
+- `1 / (1 − K β)` → falls back to the numerator `ℵⁿ + K α` if the denominator is within `eps` of zero
+
+The `Qs` cap `ρₛ ℒₛ hₛⁿ / Δt` keeps `K β` comfortably below 1 in practice; the guard is a defensive fallback rather than a routine path.
+
+## Edge cases deferred to `ice_volume_update`
+
+The closed-form solves the implicit ℵⁿ⁺¹ update but doesn't apply volume clipping, ridging, or pathological-case handling. After the
+solve, the kernel calls `ice_melt_freeze_tendency` once at the self-consistent `Quie = Qui + Qs · ℵⁿ⁺¹` and passes the resulting
+`∂t_V` through `ice_volume_update`, which handles:
+
+- `V^{n+1} = max(0, V^n + Δt ∂t_V)` when the ice melts completely
+- ridging cap `ℵ⁺ → 1` with compensating thickness adjustment
+- degenerate states (`ℵ ≤ 0`, `∂t_V = 0`, `h⁺ = 0`)
+
+## Energy conservation
+
+The implicit solve eliminates the per-step `Qs · (1 − ℵⁿ⁺¹) · Δt · A`. leak that an explicit or single-pass formulation would incur. 

--- a/docs/src/physics/layered_snow_ice_implementation.md
+++ b/docs/src/physics/layered_snow_ice_implementation.md
@@ -5,109 +5,109 @@ This page documents the snow-surface energy balance and the closed-form implicit
 
 ## Column geometry
 
-Each cell contains an ice-covered fraction `ℵ`; snow sits on the ice only. The prognostic variables are
+Each cell contains an ice-covered fraction $\aleph$; snow sits on the ice only. The prognostic variables are
 
-- `h`  — ice thickness on the ice-covered fraction (m, per-ice)
-- `ℵ`  — ice concentration (unitless, per-cell area fraction)
-- `hs` — snow thickness on the ice-covered fraction (m, per-ice)
+- $h_i$ — ice thickness on the ice-covered fraction (m, per-ice)
+- $\aleph$ — ice concentration (unitless, per-cell area fraction)
+- $h_s$ — snow thickness on the ice-covered fraction (m, per-ice)
 
-with the ice-volume invariant `V = h · ℵ` tracked per unit *cell* area. Snow volume per unit cell area is `hs · ℵ` and is conserved 
-across changes in `ℵ` by the kernel's `hs ← hs · ℵⁿ/ℵⁿ⁺¹` rescale.
+with the ice-volume invariant $V = h_i \, \aleph$ tracked per unit *cell* area. Snow volume per unit cell area is $h_s \, \aleph$ and is conserved
+across changes in $\aleph$ by the kernel's $h_s \leftarrow h_s \, \aleph^n / \aleph^{n+1}$ rescale.
 
 ## Per-ice vs. per-cell fluxes
 
 Two conventions coexist and must be treated consistently:
 
-- `Qui` (top external heat flux), `Qbi` (bottom external heat flux) are delivered by the coupler **per unit cell area** (radiation and
-  turbulent fluxes × ℵ on the ice path, interface heat × ℵ on the ocean path).
-- `Qis` (column conductive flux `(Tb − Tu)/R`, `R = hs/ks + hi/ki`) is intrinsically **per unit ice area**: the thermal resistance only
+- $Q_{ui}$ (top external heat flux) and $Q_{bi}$ (bottom external heat flux) are delivered by the coupler **per unit cell area** (radiation and
+  turbulent fluxes $\times \aleph$ on the ice path, interface heat $\times \aleph$ on the ocean path).
+- $Q_{is}$ (column conductive flux $(T_b - T_u)/R$, with $R = h_s/k_s + h_i/k_i$) is intrinsically **per unit ice area**: the thermal resistance only
   applies where ice exists.
-- `Qii` (ice-only internal conductive flux) is similarly per-ice.
+- $Q_{ii}$ (ice-only internal conductive flux) is similarly per-ice.
 
 ## Snow-surface energy balance
 
 The snow surface sits on the ice-covered fraction only, so the surface energy balance is a **per-ice** balance:
 
 ```math
-\delta Q = \frac{Qui}{\aleph^n} - Qis, \qquad
-Q_s = \min\left(\max(0, -\delta Q), \frac{\rho_s \mathcal{L}_s h_s^n}{\Delta t}\right).
+\delta Q = \frac{Q_{ui}}{\aleph^n} - Q_{is}, \qquad
+Q_s = \min\!\left(\max(0,\, -\delta Q),\; \frac{\rho_s \, \mathscr{L} \, h_s^n}{\Delta t}\right).
 ```
 
-`Qs` (positive when melting) is the per-ice latent power absorbed by snow melt, giving a thickness rate `Gs⁻ = Qs/(ρₛ ℒₛ)`.
+$Q_s$ (positive when melting) is the per-ice latent power absorbed by snow melt, giving a thickness rate $G_s^- = Q_s / (\rho_s \, \mathscr{L})$.
 
-The atmospheric flux `Qui` passed by the coupler is per-cell, so we divide by `ℵⁿ` before comparing with `Qis`. 
-When `ℵⁿ = 1` this reduces to the original formulation; when `ℵⁿ < 1` it avoids the spurious factor of `ℵⁿ` that 
+The atmospheric flux $Q_{ui}$ passed by the coupler is per-cell, so we divide by $\aleph^n$ before comparing with $Q_{is}$.
+When $\aleph^n = 1$ this reduces to the original formulation; when $\aleph^n < 1$ it avoids the spurious factor of $\aleph^n$ that
 would otherwise suppress the snow melt rate.
 
 ## Implicit concentration update
 
-The slab mass balance and the `ProportionalEvolution` concentration rule are both linear in the end-of-step concentration `ℵⁿ⁺¹`:
+The slab mass balance and the `ProportionalEvolution` concentration rule are both linear in the end-of-step concentration $\aleph^{n+1}$:
 
 ```math
-\partial_t V = \frac{(Qui + Q_s \aleph^{n+1}) - Qbi}{\rho_i \mathcal{L}}  \equiv \alpha + \beta\, \aleph^{n+1},
+\partial_t V = \frac{(Q_{ui} + Q_s \, \aleph^{n+1}) - Q_{bi}}{\rho_i \, \mathscr{L}} \;\equiv\; \alpha + \beta \, \aleph^{n+1},
 ```
 
 with
 
 ```math
-\alpha = \frac{Qui - Qbi}{\rho_i \mathcal{L}}, \quad
-\beta  = \frac{Q_s}{\rho_i \mathcal{L}},
+\alpha = \frac{Q_{ui} - Q_{bi}}{\rho_i \, \mathscr{L}}, \qquad
+\beta  = \frac{Q_s}{\rho_i \, \mathscr{L}},
 ```
 
 and
 
 ```math
-\aleph^{n+1} = \aleph^n + \Delta t\, C\, \partial_t V,
+\aleph^{n+1} = \aleph^n + \Delta t \, C \, \partial_t V,
 ```
 
 with
 
 ```math
 C = \begin{cases}
-\frac{\aleph^n}{2 h^n} & \text{if } \partial_t V < 0 \ \text{(melt)} \\
-\frac{1 - \aleph^n}{h^c} & \text{if } \partial_t V \ge 0 \ \text{(freeze)}.
+\dfrac{\aleph^n}{2 \, h_i^n} & \text{if } \partial_t V < 0 \quad \text{(melt)} \\[6pt]
+\dfrac{1 - \aleph^n}{h^c}    & \text{if } \partial_t V \ge 0 \quad \text{(freeze)}.
 \end{cases}
 ```
 
-Defining `K = Δt · C`, the fixed point `ℵⁿ⁺¹ · (1 − K β) = ℵⁿ + K α` has the **closed-form solution**
+Defining $K = \Delta t \, C$, the fixed point $\aleph^{n+1} \, (1 - K \beta) = \aleph^n + K \alpha$ has the **closed-form solution**
 
 ```math
-\boxed{\aleph^{n+1} = \frac{\aleph^n + K \alpha}{1 - K \beta}}.
+\boxed{\,\aleph^{n+1} = \frac{\aleph^n + K \alpha}{1 - K \beta}\,}.
 ```
 
 ## Branch selection
 
-The correct branch (melt vs. freeze) depends on the sign of `∂t_V` at the solution, which isn't known up front. The kernel computes *both*
-branches and picks the one where `sign(∂t_V(ℵⁿ⁺¹))` is consistent with the branch assumption:
+The correct branch (melt vs. freeze) depends on the sign of $\partial_t V$ at the solution, which isn't known up front. The kernel computes *both*
+branches, $\aleph^m$ (melt) and $\aleph^f$ (freeze), and picks the one where $\operatorname{sign}(\partial_t V(\aleph^{n+1}))$ is consistent with the branch assumption:
 
-- if `α + β · ℵᵐ < 0`, use the melt-branch solution `ℵᵐ`
-- otherwise, use the freeze-branch solution `ℵᶠ`
+- if $\alpha + \beta \, \aleph^m < 0$, use the melt-branch solution $\aleph^m$
+- otherwise, use the freeze-branch solution $\aleph^f$
 
-This is branchless (via `ifelse`) and correct at the `α ≈ 0` boundary where the first-guess sign could be misleading. On ocean scales
-`|K β| ≲ 10⁻⁶`, so the sign rarely flips between guess and solution; the test is defensive for the atypical case where atmospheric heating
+This is branchless (via `ifelse`) and correct at the $\alpha \approx 0$ boundary where the first-guess sign could be misleading. On ocean scales
+$|K \beta| \lesssim 10^{-6}$, so the sign rarely flips between guess and solution; the test is defensive for the atypical case where atmospheric heating
 almost exactly cancels the column conductive flux.
 
 ## NaN guards
 
 All divisions are protected:
 
-- `Qui / ℵⁿ`      → falls back to `0` if `ℵⁿ ≤ 0`
-- `ℵⁿ / (2 hⁿ)`   → falls back to `0` if `hⁿ ≤ 0`
-- `(1 − ℵⁿ) / hᶜ` → falls back to `0` if `hᶜ ≤ 0`
-- `1 / (1 − K β)` → falls back to the numerator `ℵⁿ + K α` if the denominator is within `eps` of zero
+- $Q_{ui} / \aleph^n$ falls back to $0$ if $\aleph^n \le 0$
+- $\aleph^n / (2 \, h_i^n)$ falls back to $0$ if $h_i^n \le 0$
+- $(1 - \aleph^n) / h^c$ falls back to $0$ if $h^c \le 0$
+- $1 / (1 - K \beta)$ falls back to the numerator $\aleph^n + K \alpha$ if the denominator is within $\varepsilon$ of zero
 
-The `Qs` cap `ρₛ ℒₛ hₛⁿ / Δt` keeps `K β` comfortably below 1 in practice; the guard is a defensive fallback rather than a routine path.
+The $Q_s$ cap $\rho_s \, \mathscr{L} \, h_s^n / \Delta t$ keeps $K \beta$ comfortably below 1 in practice; the guard is a defensive fallback rather than a routine path.
 
 ## Edge cases deferred to `ice_volume_update`
 
-The closed-form solves the implicit ℵⁿ⁺¹ update but doesn't apply volume clipping, ridging, or pathological-case handling. After the
-solve, the kernel calls `ice_melt_freeze_tendency` once at the self-consistent `Quie = Qui + Qs · ℵⁿ⁺¹` and passes the resulting
-`∂t_V` through `ice_volume_update`, which handles:
+The closed-form solves the implicit $\aleph^{n+1}$ update but doesn't apply volume clipping, ridging, or pathological-case handling. After the
+solve, the kernel calls `ice_melt_freeze_tendency` once at the self-consistent $Q_{ui}^{\mathrm{eff}} = Q_{ui} + Q_s \, \aleph^{n+1}$ and passes the resulting
+$\partial_t V$ through `ice_volume_update`, which handles:
 
-- `V^{n+1} = max(0, V^n + Δt ∂t_V)` when the ice melts completely
-- ridging cap `ℵ⁺ → 1` with compensating thickness adjustment
-- degenerate states (`ℵ ≤ 0`, `∂t_V = 0`, `h⁺ = 0`)
+- $V^{n+1} = \max(0,\, V^n + \Delta t \, \partial_t V)$ when the ice melts completely
+- ridging cap $\aleph^+ \to 1$ with compensating thickness adjustment
+- degenerate states ($\aleph \le 0$, $\partial_t V = 0$, $h^+ = 0$)
 
 ## Energy conservation
 
-The implicit solve eliminates the per-step `Qs · (1 − ℵⁿ⁺¹) · Δt · A`. leak that an explicit or single-pass formulation would incur. 
+The implicit solve eliminates the per-step $Q_s \, (1 - \aleph^{n+1}) \, \Delta t \, A$ leak that an explicit or single-pass formulation would incur.

--- a/docs/src/physics/thermodynamics.md
+++ b/docs/src/physics/thermodynamics.md
@@ -199,9 +199,10 @@ ice_thermodynamics
 ```
 
 The bulk sea-ice density is passed to [`SeaIceModel`](@ref) separately via the
-`ice_density` keyword (default `900` kg/m³), and is stored as a
+`sea_ice_density` keyword (default `900` kg/m³), and is stored as a
 `Field{Center, Center, Nothing}` on the model. It is distinct from the
-microscopic pure-ice density inside [`PhaseTransitions`](@ref).
+microscopic pure-ice density inside [`PhaseTransitions`](@ref), which refers
+to the pure ice crystal and not to the porous sea-ice matrix.
 
 ## Customising the internal flux
 
@@ -399,11 +400,11 @@ step from the resistance ratio.
 
 When running a pure-dynamics simulation (no phase physics), pass
 `ice_thermodynamics = nothing`. `SeaIceModel` still carries the bulk
-`ice_density` field that the momentum equations need, so the dynamics path
-works without a thermodynamic step:
+`sea_ice_density` field that the momentum equations need, so the dynamics
+path works without a thermodynamic step:
 
 ```@example thermodynamics
 model_dyn = SeaIceModel(grid;
     ice_thermodynamics = nothing,
-    ice_density = 900)
+    sea_ice_density = 900)
 ```

--- a/docs/src/physics/thermodynamics.md
+++ b/docs/src/physics/thermodynamics.md
@@ -38,23 +38,30 @@ phase_transitions = PhaseTransitions()
 
 ### Temperature-dependent latent heat
 
-The latent heat of fusion ``\mathscr{L}`` represents the energy required to transform ice into
-liquid water (or released during freezing). It varies with temperature:
+The latent heat of fusion ``\mathscr{L}`` is the energy per unit mass of pure ice required
+to transform ice into liquid water (or released during freezing). It varies with
+temperature through a Stefan correction:
 ```math
-\rho_i \mathscr{L}(T) = \rho_i \mathscr{L}_0 + (\rho_\ell c_\ell - \rho_i c_i)(T - T_0)
+\mathscr{L}(T) = \mathscr{L}_0 + \left(\frac{\rho_\ell c_\ell}{\rho_i} - c_i\right)(T - T_0)
 ```
-where ``\rho_i`` and ``\rho_\ell`` are the ice and liquid densities, ``c_i`` and ``c_\ell``
-are the respective heat capacities, ``\mathscr{L}_0`` is the reference latent heat at
-temperature ``T_0``, and ``T`` is the current temperature.
+where ``\rho_i, c_i`` are the **microscopic pure-ice** density and heat capacity,
+``\rho_\ell, c_\ell`` are the liquid water density and heat capacity, ``\mathscr{L}_0`` is
+the reference latent heat at temperature ``T_0``, and ``T`` is the current temperature.
+All quantities here are material properties of pure H₂O and identical for sea ice and
+snow (the ice crystals are the same substance in both media).
+
+To obtain energy per unit volume of a porous medium (snow or sea ice), multiply by the
+bulk density of that medium. This separation of the *mass-budget multiplier* from the
+*per-mass Stefan correction* matches the CICE / CLM convention.
 
 ```@example thermodynamics
 using ClimaSeaIce.SeaIceThermodynamics: latent_heat
 
-# Latent heat at different temperatures
+# Per-mass latent heat at different temperatures
 L_at_0C = latent_heat(phase_transitions, 0.0)
 L_at_minus10C = latent_heat(phase_transitions, -10.0)
-println("Latent heat at 0°C: ", L_at_0C, " J/m³")
-println("Latent heat at -10°C: ", L_at_minus10C, " J/m³")
+println("Latent heat at 0°C: ", L_at_0C, " J/kg")
+println("Latent heat at -10°C: ", L_at_minus10C, " J/kg")
 ```
 
 ## Heat fluxes and the Stefan condition
@@ -170,20 +177,133 @@ flux = FluxFunction(sensible_heat; parameters = (coefficient = 15.0, T_air = -10
 
 ## Putting it together: SlabThermodynamics
 
-The [`SlabThermodynamics`](@ref) struct combines all thermodynamic components:
+The [`SlabThermodynamics`](@ref) struct describes a single slab layer (sea ice
+or snow). It carries the top surface temperature field, the top/bottom heat
+boundary conditions, the internal conductive flux coefficient, and the
+concentration-evolution rule. Phase-transition parameters (densities, latent
+heat, liquidus) are *not* stored here — they live on the [`SeaIceModel`](@ref)
+as `phase_transitions`, shared between the ice and the (optional) snow layer.
 
 ```@example thermodynamics
 using Oceananigans
-using ClimaSeaIce.SeaIceThermodynamics: SlabThermodynamics, ConductiveFlux, MeltingConstrainedFluxBalance
+using ClimaSeaIce
+using ClimaSeaIce.SeaIceThermodynamics: MeltingConstrainedFluxBalance
 
 grid = RectilinearGrid(size=(10, 10), x=(0, 1e5), y=(0, 1e5), topology=(Periodic, Periodic, Flat))
 
-thermodynamics = SlabThermodynamics(grid;
+ice_thermodynamics = SlabThermodynamics(grid;
     top_heat_boundary_condition = MeltingConstrainedFluxBalance(),
     internal_heat_flux = ConductiveFlux(Float64; conductivity = 2.0))
 
-thermodynamics
+ice_thermodynamics
 ```
+
+The bulk sea-ice density is passed to [`SeaIceModel`](@ref) separately via the
+`ice_density` keyword (default `900` kg/m³), and is stored as a
+`Field{Center, Center, Nothing}` on the model. It is distinct from the
+microscopic pure-ice density inside [`PhaseTransitions`](@ref).
+
+## Customising the internal flux
+
+The value you pass via `internal_heat_flux = ...` to `SlabThermodynamics`
+(and to its `sea_ice_slab_thermodynamics` and `snow_slab_thermodynamics`
+helpers) is the *raw coefficient* of the layer's internal flux — not a
+`FluxFunction`. The tendency kernel wraps it in a `FluxFunction` on the
+fly, threading in `model.phase_transitions.liquidus` and the slab's bottom
+boundary condition as parameters. This avoids baking the shared liquidus
+into each slab at construction time.
+
+Four shapes are supported out of the box:
+
+### A `ConductiveFlux` (default for both ice and snow)
+
+```@example thermodynamics
+using ClimaSeaIce.SeaIceThermodynamics: ConductiveFlux
+
+ice_thermodynamics = SlabThermodynamics(grid;
+    internal_heat_flux = ConductiveFlux(Float64; conductivity = 2.0))
+```
+
+Computes `Q_i = -k (T_u - T_b) / h_i`. The most common case.
+
+### A bare `Function`
+
+Pass a kernel function directly. Its signature must match the standard
+`FluxFunction` calling convention — `(i, j, grid, Tu, clock, fields,
+parameters) -> Q`:
+
+```@example thermodynamics
+@inline function radiative_internal_flux(i, j, grid, Tu, clock, fields, parameters)
+    hi = @inbounds fields.h[i, j, 1]
+    # parameters.flux is the function itself; parameters.liquidus and
+    # parameters.bottom_heat_boundary_condition are injected by the slab.
+    return ifelse(hi ≤ 0, zero(hi), -5.0 * Tu)  # toy radiative model
+end
+
+ice_thermodynamics_rad = SlabThermodynamics(grid;
+    internal_heat_flux = radiative_internal_flux)
+```
+
+### A fully-assembled `FluxFunction`
+
+If you have already packaged the kernel, its parameters, and the
+temperature-dependence flag in a `FluxFunction`, you can pass it directly.
+The slab stores it unchanged; the tendency kernel does *not* inject its
+own `liquidus` / `bottom_heat_boundary_condition`:
+
+```@example thermodynamics
+using ClimaSeaIce.SeaIceThermodynamics: FluxFunction
+
+user_flux = FluxFunction(radiative_internal_flux;
+                         parameters = (flux = nothing, absorption = 0.8),
+                         top_temperature_dependent = true)
+
+ice_thermodynamics_fn = SlabThermodynamics(grid;
+    internal_heat_flux = user_flux)
+```
+
+This is the right choice when your flux needs parameters that the default
+liquidus/bottom-BC injection cannot supply.
+
+### A custom flux struct (extend `flux_kernel`)
+
+For more structured flux descriptions, define a concrete type and provide
+one new method:
+
+```julia
+struct NonLinearConductiveFlux{T}
+    k0 :: T
+    α  :: T   # temperature sensitivity
+end
+
+@inline function nonlinear_conductive_flux(i, j, grid, Tu, clock, fields, parameters)
+    flux = parameters.flux           # ::NonLinearConductiveFlux
+    bottom_bc = parameters.bottom_heat_boundary_condition
+    liquidus = parameters.liquidus
+    Tb = bottom_temperature(i, j, grid, bottom_bc, liquidus)
+    hi = @inbounds fields.h[i, j, 1]
+    k_eff = flux.k0 * (1 + flux.α * Tu)
+    return ifelse(hi ≤ 0, zero(hi), -k_eff * (Tu - Tb) / hi)
+end
+
+# Extend the dispatch so the slab knows how to wrap NonLinearConductiveFlux
+ClimaSeaIce.SeaIceThermodynamics.flux_kernel(::NonLinearConductiveFlux) = nonlinear_conductive_flux
+
+SlabThermodynamics(grid;
+    internal_heat_flux = NonLinearConductiveFlux(2.0, 0.01))
+```
+
+The benefit over the bare-function approach is that the flux coefficient is
+introspectable (`show`, GPU `adapt`, user copying, etc.) and carries its
+own type parameters.
+
+!!! note "Layered snow + ice coupling"
+    The layered path in `_layered_thermodynamic_time_step!` assumes that
+    each layer's flux carries a `.conductivity` field and that the coupling
+    is `IceSnowConductiveFlux` (resistors in series). Replacing the
+    internal flux with a non-conductive formulation in the layered case
+    requires changes to the layered kernel and is out of scope for the
+    current refactor.
 
 When coupled to a [`SeaIceModel`](@ref), these thermodynamics automatically compute thickness
 tendencies based on the configured heat fluxes and boundary conditions.
@@ -250,7 +370,10 @@ consolidation), the snow thickness is adjusted to conserve the snow volume
 
 ### Setting up a snow-covered model
 
-Use [`snow_slab_thermodynamics`](@ref) for convenient construction with snow defaults:
+Pass a second [`SlabThermodynamics`](@ref) via `snow_thermodynamics` (or use the
+[`snow_slab_thermodynamics`](@ref) helper, which defaults the snow conductivity
+to 0.31 W m⁻¹ K⁻¹). The model reads the bulk snow density from the
+`snow_density` keyword (default 330 kg/m³).
 
 ```@example thermodynamics
 using ClimaSeaIce
@@ -261,11 +384,26 @@ snow_thermodynamics = snow_slab_thermodynamics(grid)
 
 model = SeaIceModel(grid;
     snow_thermodynamics,
+    snow_density = 330,
     snowfall = 3e-6) # kg/m²/s
 
 set!(model, h=1, ℵ=1, hs=0.1) # 10 cm snow on 1 m ice
 ```
 
-The [`SeaIceModel`](@ref) constructor automatically wires the layered coupling:
-the snow's internal heat flux is replaced with the combined snow+ice conductive flux,
-and the ice's top boundary condition becomes a prescribed interface temperature.
+The combined snow+ice conductive flux is constructed inline inside the
+layered thermodynamic kernel from each layer's conductivity, and the
+snow-ice interface temperature ``T_{si}`` is computed analytically at each
+step from the resistance ratio.
+
+### Dynamics-only configurations
+
+When running a pure-dynamics simulation (no phase physics), pass
+`ice_thermodynamics = nothing`. `SeaIceModel` still carries the bulk
+`ice_density` field that the momentum equations need, so the dynamics path
+works without a thermodynamic step:
+
+```@example thermodynamics
+model_dyn = SeaIceModel(grid;
+    ice_thermodynamics = nothing,
+    ice_density = 900)
+```

--- a/examples/freezing_bucket.jl
+++ b/examples/freezing_bucket.jl
@@ -84,7 +84,7 @@ bottom_heat_flux = FluxFunction(frazil_ice_formation)
 #
 # Then we assemble it all into a model:
 
-model = SeaIceModel(grid; ice_thermodynamics, phase_transitions, ice_density=900, bottom_heat_flux)
+model = SeaIceModel(grid; ice_thermodynamics, phase_transitions, sea_ice_density=900, bottom_heat_flux)
 
 # Note that the default bottom heat boundary condition for `SlabThermodynamics`
 # is `IceWaterThermalEquilibrium` with freshwater. That's what we want!

--- a/examples/freezing_bucket.jl
+++ b/examples/freezing_bucket.jl
@@ -51,12 +51,11 @@ conductivity = 2 # W m⁻¹ K⁻¹
 internal_heat_flux = ConductiveFlux(; conductivity)
 
 # Note that other units besides Celsius _can_ be used, but that requires setting
-# `model.phase_transitions` with appropriate parameters. We set the ice heat capacity
-# and density as well:
+# `model.phase_transitions` with appropriate parameters. The microscopic
+# pure-ice heat capacity enters the Stefan correction to the latent heat:
 
 heat_capacity = 2100 # J kg⁻¹ K⁻¹
-density = 900 # kg m⁻³
-phase_transitions = PhaseTransitions(; heat_capacity, density)
+phase_transitions = PhaseTransitions(; heat_capacity)
 
 # We set the top ice temperature:
 
@@ -69,7 +68,6 @@ top_heat_boundary_condition = PrescribedTemperature(top_temperature)
 
 ice_thermodynamics = SlabThermodynamics(grid;
                                         internal_heat_flux,
-                                        phase_transitions,
                                         top_heat_boundary_condition)
 
 # ## Frazil ice formation
@@ -86,7 +84,7 @@ bottom_heat_flux = FluxFunction(frazil_ice_formation)
 #
 # Then we assemble it all into a model:
 
-model = SeaIceModel(grid; ice_thermodynamics, bottom_heat_flux)
+model = SeaIceModel(grid; ice_thermodynamics, phase_transitions, ice_density=900, bottom_heat_flux)
 
 # Note that the default bottom heat boundary condition for `SlabThermodynamics`
 # is `IceWaterThermalEquilibrium` with freshwater. That's what we want!

--- a/examples/freezing_of_a_lake.jl
+++ b/examples/freezing_of_a_lake.jl
@@ -208,7 +208,7 @@ function accumulate_energy_bare(sim)
     h  = sim.model.ice_thickness
     ℵ  = sim.model.ice_concentration
     pt = sim.model.phase_transitions
-    ρi = sim.model.ice_density[1, 1, 1]
+    ρi = sim.model.sea_ice_density[1, 1, 1]
     ℰ  = ρi * latent_heat(pt, 0)
     En = - h .* ℵ .* ℰ
     push!(Ei_bare, deepcopy(En))
@@ -251,7 +251,7 @@ function accumulate_energy_snow(sim)
     ℵ  = m.ice_concentration
     hs = m.snow_thickness
     pt = m.phase_transitions
-    ρi = m.ice_density[1, 1, 1]
+    ρi = m.sea_ice_density[1, 1, 1]
     ρs = m.snow_density[1, 1, 1]
     ℒ  = latent_heat(pt, 0)
     En = - ℵ .* (h .* ρi * ℒ .+ hs .* ρs * ℒ)

--- a/examples/freezing_of_a_lake.jl
+++ b/examples/freezing_of_a_lake.jl
@@ -28,7 +28,6 @@
 
 using Oceananigans
 using Oceananigans.Units
-using Oceananigans.Fields: interior
 using ClimaSeaIce
 using ClimaSeaIce.SeaIceThermodynamics: latent_heat
 using CairoMakie
@@ -209,7 +208,7 @@ function accumulate_energy_bare(sim)
     h  = sim.model.ice_thickness
     ℵ  = sim.model.ice_concentration
     pt = sim.model.phase_transitions
-    ρi = first(interior(sim.model.ice_density))
+    ρi = sim.model.ice_density[1, 1, 1]
     ℰ  = ρi * latent_heat(pt, 0)
     En = - h .* ℵ .* ℰ
     push!(Ei_bare, deepcopy(En))
@@ -252,8 +251,8 @@ function accumulate_energy_snow(sim)
     ℵ  = m.ice_concentration
     hs = m.snow_thickness
     pt = m.phase_transitions
-    ρi = first(interior(m.ice_density))
-    ρs = first(interior(m.snow_density))
+    ρi = m.ice_density[1, 1, 1]
+    ρs = m.snow_density[1, 1, 1]
     ℒ  = latent_heat(pt, 0)
     En = - ℵ .* (h .* ρi * ℒ .+ hs .* ρs * ℒ)
     push!(Ei_snow_ts, deepcopy(En))
@@ -328,7 +327,7 @@ nothing # hide
 # budget is: dE/dt = -Qa + Ql + Qp, where Qp is the precipitation latent
 # heat flux. We compute Qp from the snow thickness change due to accumulation.
 
-ρs_snow = first(interior(model_snow.snow_density))
+ρs_snow = model_snow.snow_density[1, 1, 1]
 ℒs_snow = model_snow.phase_transitions.reference_latent_heat
 
 fig = Figure(size=(1200, 1000))

--- a/examples/freezing_of_a_lake.jl
+++ b/examples/freezing_of_a_lake.jl
@@ -28,6 +28,7 @@
 
 using Oceananigans
 using Oceananigans.Units
+using Oceananigans.Fields: interior
 using ClimaSeaIce
 using ClimaSeaIce.SeaIceThermodynamics: latent_heat
 using CairoMakie
@@ -207,8 +208,9 @@ Ql_bare_ts = []
 function accumulate_energy_bare(sim)
     h  = sim.model.ice_thickness
     ℵ  = sim.model.ice_concentration
-    PT = sim.model.ice_thermodynamics.phase_transitions
-    ℰ  = latent_heat(PT, 0)
+    pt = sim.model.phase_transitions
+    ρi = first(interior(sim.model.ice_density))
+    ℰ  = ρi * latent_heat(pt, 0)
     En = - h .* ℵ .* ℰ
     push!(Ei_bare, deepcopy(En))
     push!(Qa_bare_ts, deepcopy(atmosphere.atmosphere_ice_flux))
@@ -249,11 +251,11 @@ function accumulate_energy_snow(sim)
     h  = m.ice_thickness
     ℵ  = m.ice_concentration
     hs = m.snow_thickness
-    PT = m.ice_thermodynamics.phase_transitions
-    ℰi = latent_heat(PT, 0)
-    ρs = snow_thermodynamics.phase_transitions.density
-    ℒs = snow_thermodynamics.phase_transitions.reference_latent_heat
-    En = - ℵ .* (h .* ℰi .+ hs .* ρs * ℒs)
+    pt = m.phase_transitions
+    ρi = first(interior(m.ice_density))
+    ρs = first(interior(m.snow_density))
+    ℒ  = latent_heat(pt, 0)
+    En = - ℵ .* (h .* ρi * ℒ .+ hs .* ρs * ℒ)
     push!(Ei_snow_ts, deepcopy(En))
     push!(Qa_snow_ts, deepcopy(atmosphere_snow.atmosphere_ice_flux))
     push!(Ql_snow_ts, deepcopy(lake_snow.lake_ice_flux))
@@ -326,8 +328,8 @@ nothing # hide
 # budget is: dE/dt = -Qa + Ql + Qp, where Qp is the precipitation latent
 # heat flux. We compute Qp from the snow thickness change due to accumulation.
 
-ρs_snow = snow_thermodynamics.phase_transitions.density
-ℒs_snow = snow_thermodynamics.phase_transitions.reference_latent_heat
+ρs_snow = first(interior(model_snow.snow_density))
+ℒs_snow = model_snow.phase_transitions.reference_latent_heat
 
 fig = Figure(size=(1200, 1000))
 

--- a/src/ClimaSeaIce.jl
+++ b/src/ClimaSeaIce.jl
@@ -21,7 +21,7 @@ import Oceananigans.TimeSteppers: time_step!, update_state!
 import Oceananigans.TurbulenceClosures: cell_diffusion_timescale
 import Oceananigans.Utils: prettytime
 
-export SeaIceModel, 
+export SeaIceModel,
        MeltingConstrainedFluxBalance,
        PrescribedTemperature,
        RadiativeEmission,

--- a/src/SeaIceDynamics/explicit_momentum_equations.jl
+++ b/src/SeaIceDynamics/explicit_momentum_equations.jl
@@ -19,7 +19,7 @@ function time_step_momentum!(model, ::ExplicitMomentumEquation, Δt)
     model_fields = merge(dynamics.auxiliaries.fields, model.velocities, 
                       (; h = model.ice_thickness, 
                          ℵ = model.ice_concentration, 
-                         ρ = model.ice_density))
+                         ρ = model.sea_ice_density))
 
 
     free_drift = dynamics.free_drift
@@ -84,7 +84,7 @@ function compute_momentum_tendencies!(model, ::ExplicitMomentumEquation, Δt)
     model_fields = merge(dynamics.auxiliaries.fields, model.velocities, 
             (; h = model.ice_thickness, 
                ℵ = model.ice_concentration, 
-               ρ = model.ice_density))
+               ρ = model.sea_ice_density))
 
     top_stress = dynamics.external_momentum_stresses.top
     bottom_stress = dynamics.external_momentum_stresses.bottom

--- a/src/SeaIceDynamics/split_explicit_momentum_equations.jl
+++ b/src/SeaIceDynamics/split_explicit_momentum_equations.jl
@@ -85,7 +85,7 @@ function time_step_momentum!(model, dynamics::SplitExplicitMomentumEquation, Δt
     model_fields = merge(dynamics.auxiliaries.fields, model.velocities,
                       (; h = model.ice_thickness,
                          ℵ = model.ice_concentration,
-                         ρ = model.ice_density))
+                         ρ = model.sea_ice_density))
 
     params = dynamics.solver.kernel_parameters
 

--- a/src/SeaIceThermodynamics/SeaIceThermodynamics.jl
+++ b/src/SeaIceThermodynamics/SeaIceThermodynamics.jl
@@ -133,15 +133,35 @@ function Base.show(io::IO, pt::PhaseTransitions{FT}) where FT
     print(io, "└── liquidus: ", summary(pt.liquidus))
 end
 
-@inline function latent_heat(thermo::PhaseTransitions, T)
-    T₀ = thermo.reference_temperature
-    ℒ₀ = thermo.reference_latent_heat
-    ρ  = thermo.density
-    ρℓ = thermo.liquid_density
-    c  = thermo.heat_capacity
-    cℓ = thermo.liquid_heat_capacity
+"""
+    latent_heat(phase_transitions::PhaseTransitions, T)
 
-    return ρ * ℒ₀ + (ρℓ * cℓ - ρ * c) * (T - T₀)
+Return the per-mass latent heat of fusion of pure ice at temperature `T`,
+
+```math
+ℒ(T) = ℒ₀ + \\left(\\frac{ρ_ℓ c_ℓ}{ρ} - c\\right)(T - T₀) ,
+```
+
+where `ρ`, `c` are the microscopic pure-ice density and heat capacity,
+`ρ_ℓ`, `c_ℓ` are the liquid density and heat capacity, and `T₀` is the
+reference temperature at which the reference latent heat `ℒ₀` is defined.
+
+This is the per-mass form of the volumetric expression
+`ρ ℒ(T) = ρ ℒ₀ + (ρ_ℓ c_ℓ - ρ c)(T - T₀)` (divided through by `ρ`).
+
+The returned quantity is per unit mass of pure ice. To obtain energy per
+unit volume of a porous medium (snow or sea ice), multiply by the bulk
+density of that medium.
+"""
+@inline function latent_heat(phase_transitions::PhaseTransitions, T)
+    T₀ = phase_transitions.reference_temperature
+    ℒ₀ = phase_transitions.reference_latent_heat
+    ρ  = phase_transitions.density
+    ρℓ = phase_transitions.liquid_density
+    c  = phase_transitions.heat_capacity
+    cℓ = phase_transitions.liquid_heat_capacity
+
+    return ℒ₀ + (ρℓ * cℓ / ρ - c) * (T - T₀)
 end
 
 # Fallback for no ice_thermodynamics

--- a/src/SeaIceThermodynamics/slab_sea_ice_thermodynamics.jl
+++ b/src/SeaIceThermodynamics/slab_sea_ice_thermodynamics.jl
@@ -84,7 +84,7 @@ end
 
 Construct a `SlabThermodynamics` with default parameters appropriate for sea ice:
 conductivity = 2 W/(m K). Bulk density and all phase-transition parameters live
-on `SeaIceModel` (as `ice_density` and `phase_transitions` respectively).
+on `SeaIceModel` (as `sea_ice_density` and `phase_transitions` respectively).
 """
 sea_ice_slab_thermodynamics(grid; kw...) = SlabThermodynamics(grid; kw...)
 

--- a/src/SeaIceThermodynamics/slab_sea_ice_thermodynamics.jl
+++ b/src/SeaIceThermodynamics/slab_sea_ice_thermodynamics.jl
@@ -2,19 +2,17 @@ import Oceananigans: fields, prognostic_fields, prognostic_state, restore_progno
 
 struct ProportionalEvolution end
 
-struct SlabThermodynamics{ST, HBC, CF, P, CE}
-    top_surface_temperature :: ST
-    heat_boundary_conditions :: HBC
-    internal_heat_flux :: CF
-    phase_transitions :: P
-    concentration_evolution :: CE
+struct SlabThermodynamics{ST, HBC, CF, CE}
+    top_surface_temperature   :: ST
+    heat_boundary_conditions  :: HBC
+    internal_heat_flux        :: CF
+    concentration_evolution   :: CE
 end
 
 Adapt.adapt_structure(to, t::SlabThermodynamics) =
     SlabThermodynamics(Adapt.adapt(to, t.top_surface_temperature),
                        Adapt.adapt(to, t.heat_boundary_conditions),
                        Adapt.adapt(to, t.internal_heat_flux),
-                       Adapt.adapt(to, t.phase_transitions),
                        Adapt.adapt(to, t.concentration_evolution))
 
 const SSIT = SlabThermodynamics
@@ -23,24 +21,16 @@ const SSIT = SlabThermodynamics
     snow_slab_thermodynamics(grid; kw...)
 
 Construct a `SlabThermodynamics` with default parameters appropriate for snow:
-conductivity = 0.31 W/(m K), density = 330 kg/m³, heat capacity = 2090 J/(kg K),
-and latent heat = 334000 J/kg.
+conductivity = 0.31 W/(m K). Bulk density and all phase-transition parameters
+live on `SeaIceModel` (as `snow_density` and `phase_transitions` respectively).
 """
 function snow_slab_thermodynamics(grid;
-                                  conductivity          = 0.31,
-                                  density               = 330,
-                                  heat_capacity         = 2090,
-                                  reference_latent_heat = 334e3,
+                                  conductivity = 0.31,
                                   kw...)
 
     FT = eltype(grid)
     internal_heat_flux = ConductiveFlux(FT, conductivity = conductivity)
-    phase_transitions  = PhaseTransitions(FT;
-                                          density               = density,
-                                          heat_capacity         = heat_capacity,
-                                          reference_latent_heat = reference_latent_heat)
-
-    return SlabThermodynamics(grid; internal_heat_flux, phase_transitions, kw...)
+    return SlabThermodynamics(grid; internal_heat_flux, kw...)
 end
 
 Base.summary(therm::SSIT) = "SlabThermodynamics"
@@ -53,15 +43,15 @@ end
 fields(therm::SSIT) = (; Tu = therm.top_surface_temperature)
 prognostic_fields(therm::SSIT) = NamedTuple()
 
-flux_function(internal_heat_flux::Function) = internal_heat_flux
-flux_function(internal_heat_flux::ConductiveFlux) = slab_internal_heat_flux
-flux_function(internal_heat_flux::IceSnowConductiveFlux) = ice_snow_conductive_flux
-
-
 """
     SlabThermodynamics(grid; kw...)
 
-Pretty simple model for sea ice.
+A minimal slab representation of a single sea-ice or snow layer. Stores
+the top surface temperature, top/bottom heat boundary conditions, the raw
+internal-flux coefficient (e.g. a `ConductiveFlux`), and the concentration
+evolution rule. Phase-transition parameters (densities, latent heats,
+liquidus) are stored at the `SeaIceModel` level and threaded into the
+tendency kernels via `model.phase_transitions`.
 """
 function SlabThermodynamics(grid;
                             top_surface_temperature        = nothing,
@@ -69,18 +59,7 @@ function SlabThermodynamics(grid;
                             bottom_heat_boundary_condition = IceWaterThermalEquilibrium(),
                             # Default internal flux: thermal conductivity of 2 kg m s⁻³ K⁻¹, appropriate for freshwater ice
                             internal_heat_flux             = ConductiveFlux(eltype(grid), conductivity=2),
-                            phase_transitions              = PhaseTransitions(eltype(grid)),
                             concentration_evolution        = ProportionalEvolution())
-
-    # Construct an internal heat flux function that captures the liquidus and
-    # bottom boundary condition.
-    parameters = (flux = internal_heat_flux,
-                  liquidus = phase_transitions.liquidus,
-                  bottom_heat_boundary_condition = bottom_heat_boundary_condition)
-
-    internal_heat_flux_function = FluxFunction(flux_function(internal_heat_flux);
-                                               parameters,
-                                               top_temperature_dependent=true)
 
     if isnothing(top_surface_temperature)
         if top_heat_boundary_condition isa PrescribedTemperature
@@ -96,8 +75,7 @@ function SlabThermodynamics(grid;
 
     return SlabThermodynamics(top_surface_temperature,
                               heat_boundary_conditions,
-                              internal_heat_flux_function,
-                              phase_transitions,
+                              internal_heat_flux,
                               concentration_evolution)
 end
 
@@ -105,10 +83,92 @@ end
     sea_ice_slab_thermodynamics(grid; kw...)
 
 Construct a `SlabThermodynamics` with default parameters appropriate for sea ice:
-conductivity = 2 W/(m K), density = 917 kg/m³, heat capacity = 2000 J/(kg K),
-and latent heat = 334000 J/kg.
+conductivity = 2 W/(m K). Bulk density and all phase-transition parameters live
+on `SeaIceModel` (as `ice_density` and `phase_transitions` respectively).
 """
 sea_ice_slab_thermodynamics(grid; kw...) = SlabThermodynamics(grid; kw...)
+
+#####
+##### Flux-function assembly (used by tendency kernels)
+#####
+
+"""
+    internal_flux_function(flux, liquidus, bottom_heat_boundary_condition)
+
+Wrap a raw internal-flux coefficient (`ConductiveFlux`, `IceSnowConductiveFlux`,
+user `Function`, or user struct) in the `FluxFunction` shape expected by the
+surface-temperature solver and by `getflux`. The wrapper is built at the
+tendency-kernel level so that `liquidus` and `bottom_heat_boundary_condition`
+can be read from `model.phase_transitions` and the slab's heat BCs without
+threading those values through `SlabThermodynamics` at construction time.
+
+If `flux` is already a `FluxFunction`, it is returned unchanged — the user
+is assumed to have fully assembled the wrapper themselves, and the kernel
+does not inject its own parameters.
+
+To plug a custom flux-coefficient struct into the bare-ice slab, extend the
+`flux_kernel` dispatch:
+
+```julia
+struct MyInternalFlux{T}
+    some_parameter :: T
+end
+
+# Signature must match the standard FluxFunction kernel:
+#   (i, j, grid, Tu, clock, fields, parameters) -> Q
+@inline function my_internal_flux(i, j, grid, Tu, clock, fields, parameters)
+    flux = parameters.flux         # ::MyInternalFlux
+    # ...use `flux.some_parameter`, `fields.h`, etc...
+end
+
+ClimaSeaIce.SeaIceThermodynamics.flux_kernel(::MyInternalFlux) = my_internal_flux
+```
+
+Once `flux_kernel` dispatches, `MyInternalFlux` can be passed to any
+`SlabThermodynamics`/`sea_ice_slab_thermodynamics`/`snow_slab_thermodynamics`
+constructor as `internal_heat_flux = MyInternalFlux(...)`.
+
+The layered snow+ice path additionally assumes that each layer's flux
+coefficient carries a `.conductivity` field and that the coupling is
+resistors-in-series. Custom flux types for a layered column are out of
+scope for this refactor.
+"""
+@inline function internal_flux_function(flux, liquidus, bottom_heat_boundary_condition)
+    parameters = (flux = flux,
+                  liquidus = liquidus,
+                  bottom_heat_boundary_condition = bottom_heat_boundary_condition)
+
+    return FluxFunction(flux_kernel(flux);
+                        parameters,
+                        top_temperature_dependent = true)
+end
+
+# Pass-through when the user has already assembled the `FluxFunction` wrapper.
+@inline internal_flux_function(f::FluxFunction, liquidus, bottom_heat_boundary_condition) = f
+
+"""
+    flux_kernel(flux)
+
+Return the kernel function that computes the slab's internal heat flux given
+a raw flux-coefficient `flux`. This is a public extension point: users who
+define a custom flux struct should add a method
+
+```julia
+ClimaSeaIce.SeaIceThermodynamics.flux_kernel(::MyFlux) = my_flux_kernel
+```
+
+where `my_flux_kernel(i, j, grid, Tu, clock, fields, parameters)` returns a
+heat flux with `parameters.flux::MyFlux`.
+
+Built-in dispatches:
+
+- `ConductiveFlux` → `slab_internal_heat_flux` (single-layer Fourier)
+- `IceSnowConductiveFlux` → `ice_snow_conductive_flux` (resistors in series)
+- `Function` → returned directly (the function is its own kernel)
+"""
+@inline flux_kernel(::ConductiveFlux) = slab_internal_heat_flux
+@inline flux_kernel(::IceSnowConductiveFlux) = ice_snow_conductive_flux
+@inline flux_kernel(f::Function) = f
 
 #####
 ##### Checkpointing

--- a/src/SeaIceThermodynamics/slab_thermodynamics_tendencies.jl
+++ b/src/SeaIceThermodynamics/slab_thermodynamics_tendencies.jl
@@ -1,69 +1,64 @@
 using ClimaSeaIce.SeaIceThermodynamics.HeatBoundaryConditions: bottom_temperature, top_surface_temperature
 using Oceananigans
 
-@inline function thermodynamic_tendency(i, j, k, grid,
-                                        ice_thermodynamics::SlabThermodynamics,
-                                        ice_thickness,
-                                        ice_concentration,
-                                        ice_consolidation_thickness,
-                                        top_external_heat_flux,
-                                        bottom_external_heat_flux,
-                                        clock, model_fields)
+#####
+##### Ice interior conductive flux
+#####
 
-    phase_transitions = ice_thermodynamics.phase_transitions
+# Given the wrapped `FluxFunction` for the ice layer, evaluate the
+# conductive flux at the ice-top temperature. Both the bare-ice path and
+# the layered path build the wrapper inline before calling here.
+@inline function ice_interior_heat_flux(Qi_function,
+                                        i, j, k, grid, Tui,
+                                        consolidated_ice, clock, model_fields)
+    # If the ice is consolidated, we use the internal heat flux.
+    # Slab is unconsolidated, there is no internal heat flux (Qi -> ∞)
+    return ifelse(consolidated_ice,
+                  getflux(Qi_function, i, j, grid, Tui, clock, model_fields),
+                  zero(grid))
+end
 
-    top_heat_bc = ice_thermodynamics.heat_boundary_conditions.top
+#####
+##### Pure ice melt/freeze tendency
+#####
+
+# Given an externally-determined ice-top temperature `Tui` and top external
+# flux `top_effective_heat_flux` (which may already include snow-surface
+# absorption), compute the volume tendency of the ice slab. No surface solve
+# is performed here.
+@inline function ice_melt_freeze_tendency(i, j, k, grid,
+                                          ice_thermodynamics::SlabThermodynamics,
+                                          phase_transitions,
+                                          ice_density,
+                                          Qi_function,
+                                          Tui,
+                                          ice_thickness,
+                                          ice_consolidation_thickness,
+                                          top_effective_heat_flux,
+                                          bottom_external_heat_flux,
+                                          clock, model_fields)
+
     bottom_heat_bc = ice_thermodynamics.heat_boundary_conditions.bottom
     liquidus = phase_transitions.liquidus
 
-    Qi = ice_thermodynamics.internal_heat_flux
-    Qu = top_external_heat_flux
-    Qb = bottom_external_heat_flux
-    Tu = ice_thermodynamics.top_surface_temperature
-
-    @inbounds begin
-        hi = ice_thickness[i, j, k]
-        hc = ice_consolidation_thickness[i, j, k]
-        Si = model_fields.S[i, j, k]
-    end
-
-    @inbounds Tui = Tu[i, j, k]
+    @inbounds hi = ice_thickness[i, j, k]
+    @inbounds hc = ice_consolidation_thickness[i, j, k]
+    @inbounds ρi = ice_density[i, j, 1]
 
     consolidated_ice = hi ≥ hc
 
-    # Determine top surface temperature. 
-    # Does this really fit here?
-    # This is updating the temperature inside the ice_thermodynamics module
-    if !isa(top_heat_bc, PrescribedTemperature) # update surface temperature?
-        if consolidated_ice # slab is consolidated and has an independent surface temperature
-            Tu⁻ = @inbounds Tu[i, j, k]
-            Tuⁿ = top_surface_temperature(i, j, grid, top_heat_bc, Tu⁻, Qi, Qu, clock, model_fields)
-            # We cap by melting temperature
-            Tuₘ = melting_temperature(liquidus, Si)
-            Tuⁿ = min(Tuⁿ, Tuₘ)
-        else # slab is unconsolidated and does not have an independent surface temperature
-            Tuⁿ = bottom_temperature(i, j, grid, bottom_heat_bc, liquidus)
-        end
-
-        @inbounds Tu[i, j, k] = Tuⁿ
-    end
-
-    @inbounds Tui = Tu[i, j, k]
-
     Tbi = bottom_temperature(i, j, grid, bottom_heat_bc, liquidus)
-    ℰb = latent_heat(phase_transitions, Tbi)
-    ℰu = latent_heat(phase_transitions, Tui)
+
+    # Energy per unit volume of sea-ice: bulk-density × per-mass latent heat
+    ℰb = ρi * latent_heat(phase_transitions, Tbi)
+    ℰu = ρi * latent_heat(phase_transitions, Tui)
 
     # Retrieve fluxes
-    Qui = getflux(Qu, i, j, grid, Tui, clock, model_fields)
-    Qbi = getflux(Qb, i, j, grid, Tui, clock, model_fields)
+    Qui = getflux(top_effective_heat_flux, i, j, grid, Tui, clock, model_fields)
+    Qbi = getflux(bottom_external_heat_flux, i, j, grid, Tui, clock, model_fields)
+    Qii = ice_interior_heat_flux(Qi_function, i, j, k, grid, Tui,
+                                 consolidated_ice, clock, model_fields)
 
-    if consolidated_ice # If the ice is consolidated, we use the internal heat flux
-        Qii = getflux(Qi, i, j, grid, Tui, clock, model_fields)
-    else # Slab is unconsolidated, there is no internal heat flux (Qi -> ∞)
-        Qii = zero(grid)
-    end
-    
     # Upper (top) and bottom interface velocities
     # wu < 0 => top melting (volume loss from top)
     # wb > 0 => bottom freezing (volume gain at bottom)
@@ -71,4 +66,64 @@ using Oceananigans
     wb = (Qii - Qbi) / ℰb
 
     return wu + wb
+end
+
+#####
+##### Top-level tendency with surface solve (bare-ice entry point)
+#####
+
+@inline function thermodynamic_tendency(i, j, k, grid,
+                                        ice_thermodynamics::SlabThermodynamics,
+                                        phase_transitions,
+                                        ice_density,
+                                        ice_thickness,
+                                        ice_concentration,
+                                        ice_consolidation_thickness,
+                                        top_external_heat_flux,
+                                        bottom_external_heat_flux,
+                                        clock, model_fields)
+
+    top_heat_bc = ice_thermodynamics.heat_boundary_conditions.top
+    bottom_heat_bc = ice_thermodynamics.heat_boundary_conditions.bottom
+    liquidus = phase_transitions.liquidus
+
+    # Build the internal-flux wrapper inline using the model's shared liquidus.
+    Qi_function = internal_flux_function(ice_thermodynamics.internal_heat_flux,
+                                         liquidus, bottom_heat_bc)
+    Qu = top_external_heat_flux
+    Tu = ice_thermodynamics.top_surface_temperature
+
+    @inbounds hi = ice_thickness[i, j, k]
+    @inbounds hc = ice_consolidation_thickness[i, j, k]
+    @inbounds Si = model_fields.S[i, j, k]
+
+    consolidated_ice = hi ≥ hc
+
+    # Determine top surface temperature.
+    # Does this really fit here?
+    # This is updating the temperature inside the ice_thermodynamics module
+    if !isa(top_heat_bc, PrescribedTemperature) # update surface temperature?
+        if consolidated_ice # slab is consolidated and has an independent surface temperature
+            @inbounds Tu⁻ = Tu[i, j, k]
+            Tuⁿ = top_surface_temperature(i, j, grid, top_heat_bc, Tu⁻, Qi_function, Qu, clock, model_fields)
+            # We cap by melting temperature
+            Tuₘ = melting_temperature(liquidus, Si)
+            Tuⁿ = min(Tuⁿ, Tuₘ)
+        else # slab is unconsolidated and does not have an independent surface temperature
+            Tuⁿ = bottom_temperature(i, j, grid, bottom_heat_bc, liquidus)
+        end
+        @inbounds Tu[i, j, k] = Tuⁿ
+    end
+
+    @inbounds Tui = Tu[i, j, k]
+
+    return ice_melt_freeze_tendency(i, j, k, grid,
+                                    ice_thermodynamics,
+                                    phase_transitions,
+                                    ice_density,
+                                    Qi_function,
+                                    Tui,
+                                    ice_thickness, ice_consolidation_thickness,
+                                    Qu, bottom_external_heat_flux,
+                                    clock, model_fields)
 end

--- a/src/SeaIceThermodynamics/slab_thermodynamics_tendencies.jl
+++ b/src/SeaIceThermodynamics/slab_thermodynamics_tendencies.jl
@@ -29,7 +29,7 @@ end
 @inline function ice_melt_freeze_tendency(i, j, k, grid,
                                           ice_thermodynamics::SlabThermodynamics,
                                           phase_transitions,
-                                          ice_density,
+                                          sea_ice_density,
                                           Qi_function,
                                           Tui,
                                           ice_thickness,
@@ -43,7 +43,7 @@ end
 
     @inbounds hi = ice_thickness[i, j, k]
     @inbounds hc = ice_consolidation_thickness[i, j, k]
-    @inbounds ρi = ice_density[i, j, 1]
+    @inbounds ρi = sea_ice_density[i, j, 1]
 
     consolidated_ice = hi ≥ hc
 
@@ -75,7 +75,7 @@ end
 @inline function thermodynamic_tendency(i, j, k, grid,
                                         ice_thermodynamics::SlabThermodynamics,
                                         phase_transitions,
-                                        ice_density,
+                                        sea_ice_density,
                                         ice_thickness,
                                         ice_concentration,
                                         ice_consolidation_thickness,
@@ -120,7 +120,7 @@ end
     return ice_melt_freeze_tendency(i, j, k, grid,
                                     ice_thermodynamics,
                                     phase_transitions,
-                                    ice_density,
+                                    sea_ice_density,
                                     Qi_function,
                                     Tui,
                                     ice_thickness, ice_consolidation_thickness,

--- a/src/SeaIceThermodynamics/slab_thermodynamics_tendencies.jl
+++ b/src/SeaIceThermodynamics/slab_thermodynamics_tendencies.jl
@@ -117,6 +117,11 @@ end
 
     @inbounds Tui = Tu[i, j, k]
 
+    # Evaluate the external flux closures exactly once at the converged Tui and pass the
+    # scalar values down to `ice_melt_freeze_tendency` (which accepts Number via `getflux`).
+    Qui = getflux(Qu, i, j, grid, Tui, clock, model_fields)
+    Qbi = getflux(bottom_external_heat_flux, i, j, grid, Tui, clock, model_fields)
+
     return ice_melt_freeze_tendency(i, j, k, grid,
                                     ice_thermodynamics,
                                     phase_transitions,
@@ -124,6 +129,6 @@ end
                                     Qi_function,
                                     Tui,
                                     ice_thickness, ice_consolidation_thickness,
-                                    Qu, bottom_external_heat_flux,
+                                    Qui, Qbi,
                                     clock, model_fields)
 end

--- a/src/SeaIceThermodynamics/thermodynamic_time_step.jl
+++ b/src/SeaIceThermodynamics/thermodynamic_time_step.jl
@@ -246,6 +246,7 @@ end
     ℵtmp    = ifelse(melting, ℵᵐ, ℵᶠ)
 
     # Final state via `ice_volume_update` (handles V<0 clipping, ridging, etc.).
+    # Pass the cached Qbi scalar (not the closure) so the bottom-flux closure is evaluated exactly once per step
     Quie = Qui + Qs * ℵtmp
     ∂t_V = ice_melt_freeze_tendency(i, j, 1, grid,
                                     ice_thermodynamics,
@@ -254,7 +255,7 @@ end
                                     Qii,
                                     Tsi,
                                     ice_thickness, ice_consolidation_thickness,
-                                    Quie, bottom_external_heat_flux,
+                                    Quie, Qbi,
                                     clock, model_fields)
 
     hiⁿ⁺¹, ℵⁿ⁺¹ = ice_volume_update(ice_thermodynamics, ∂t_V, hiⁿ, ℵⁿ, hᶜ, Δt)

--- a/src/SeaIceThermodynamics/thermodynamic_time_step.jl
+++ b/src/SeaIceThermodynamics/thermodynamic_time_step.jl
@@ -162,10 +162,12 @@ end
     ks = snow_thermodynamics.internal_heat_flux.conductivity
     ki = ice_thermodynamics.internal_heat_flux.conductivity
     combined_flux = IceSnowConductiveFlux(ks, ki)
-    Qi_column = internal_flux_function(combined_flux, liquidus, bottom_bc)
+    
+    # Column internal heat flux
+    Qic = internal_flux_function(combined_flux, liquidus, bottom_bc)
 
     # Ice-only flux wrapper for the ice-interior evaluation at Tsi.
-    Qi_ice = internal_flux_function(ice_thermodynamics.internal_heat_flux, liquidus, bottom_bc)
+    Qii = internal_flux_function(ice_thermodynamics.internal_heat_flux, liquidus, bottom_bc)
 
     snow_top_bc = snow_thermodynamics.heat_boundary_conditions.top
     Tu = snow_thermodynamics.top_surface_temperature
@@ -177,7 +179,7 @@ end
     if !isa(snow_top_bc, PrescribedTemperature)
         if consolidated_ice
             @inbounds Tu⁻ = Tu[i, j, 1]
-            Tuⁿ = top_surface_temperature(i, j, grid, snow_top_bc, Tu⁻, Qi_column, Qu, clock, model_fields)
+            Tuⁿ = top_surface_temperature(i, j, grid, snow_top_bc, Tu⁻, Qic, Qu, clock, model_fields)
             Tuⁿ = min(Tuⁿ, Tm)
         else
             Tuⁿ = Tb
@@ -191,35 +193,68 @@ end
     # When hs = 0: Tsi = Tus (snow layer has zero resistance)
     Tsi = interface_temperature(i, j, grid, combined_flux, bottom_bc, liquidus, Tus, model_fields)
 
-    # Snow surface melt energy (uses ℒ₀ since the surface solve caps Tus at 0 C)
-    Qis = ifelse(consolidated_ice, getflux(Qi_column, i, j, grid, Tus, clock, model_fields), zero(grid))
+    # Snow-surface energy balance (Qis per-ice column flux, Qui per-cell from
+    # the coupler). Compare like with like by converting Qui to per-ice;
+    # Qui/ℵⁿ = Qui when ℵⁿ = 1, and restores the correct per-ice driving
+    # flux when ℵⁿ < 1.
+    Qis = ifelse(consolidated_ice, getflux(Qic, i, j, grid, Tus, clock, model_fields), zero(grid))
     Qui = getflux(Qu, i, j, grid, Tus, clock, model_fields)
 
-    # δQ < 0 means more internal flux than external → energy available for melting
-    δQ = Qui - Qis
-    melt_energy = max(zero(δQ), -δQ) # positive when melting
+    Qui_per_ice = ifelse(ℵⁿ > 0, Qui / ℵⁿ, zero(Qui))
+
+    δQ = Qui_per_ice - Qis                       # δQ < 0 ⇒ energy available for melt
+    melt_energy = max(zero(δQ), -δQ)             # per-ice
 
     @inbounds ρs = snow_density[i, j, 1]
     ℒs = phase_transitions.reference_latent_heat
 
-    snow_energy_capacity = ρs * ℒs * hsⁿ / Δt # W/m²
-    Qs = min(melt_energy, snow_energy_capacity)
-    Gs⁻ = Qs / (ρs * ℒs)
+    snow_energy_capacity = ρs * ℒs * hsⁿ / Δt    # per-ice
+    Qs  = min(melt_energy, snow_energy_capacity) # per-ice
+    Gs⁻ = Qs / (ρs * ℒs)                         # per-ice, drives Δhs
 
-    # The effective top flux for the ice is Qui + Qs.
-    # Snow absorbing melt energy acts as extra cooling from the ice's perspective:
-    # the ice-interior flux is evaluated at Tsi, so  wu = (Qui + Qs - Qii) / ℰu
-    # and wb = (Qii - Qb) / ℰb.
-    Qui_eff = Qui + Qs
+    # Closed-form self-consistent solve for ℵⁿ⁺¹. The ice-top effective flux
+    # Quie = Qui + Qs·ℵⁿ⁺¹ couples Quie and ℵⁿ⁺¹ linearly; the slab's
+    # concentration rule is also linear in ∂t_V, so the fixed point
+    #   ∂t_V = α + β·ℵⁿ⁺¹,    α = (Qui − Qbi)/(ρᵢℒ),  β = Qs/(ρᵢℒ)
+    #   ℵⁿ⁺¹ = ℵⁿ + K·∂t_V,   K = Δt · C,
+    #   C = ℵⁿ/(2hⁿ) (melt)  or  (1−ℵⁿ)/hᶜ (freeze)
+    # has the explicit solution  ℵⁿ⁺¹ = (ℵⁿ + K·α) / (1 − K·β).
+    # Solve both branches and pick the one with sign(∂t_V(ℵⁿ⁺¹)) consistent
+    # with its branch assumption. |K·β| ≲ 10⁻⁶ at ocean scales so the denominators are
+    # safely away from zero in practice; all divisions are NaN-guarded.
+    @inbounds ρi = sea_ice_density[i, j, 1]
+    ρiℒ = ρi * ℒs
+    Qbi = getflux(bottom_external_heat_flux, i, j, grid, Tus, clock, model_fields)
 
+    α = (Qui - Qbi) / ρiℒ  # per-cell volume rate
+    β = Qs / ρiℒ           # coefficient on ℵⁿ⁺¹
+
+    Cᵐ = ifelse(hiⁿ > zero(hiⁿ), ℵⁿ / (2 * hiⁿ), zero(hiⁿ))
+    Cᶠ = ifelse(hᶜ  > zero(hᶜ),  (1 - ℵⁿ) / hᶜ,  zero(hᶜ))
+    Kᵐ = Δt * Cᵐ
+    Kᶠ = Δt * Cᶠ
+
+    ε  = eps(typeof(β))
+    Dᵐ = 1 - Kᵐ * β
+    Dᶠ = 1 - Kᶠ * β
+    ℵᵐ = ifelse(abs(Dᵐ) > ε, (ℵⁿ + Kᵐ * α) / Dᵐ, ℵⁿ + Kᵐ * α)
+    ℵᶠ = ifelse(abs(Dᶠ) > ε, (ℵⁿ + Kᶠ * α) / Dᶠ, ℵⁿ + Kᶠ * α)
+
+    # Branch selection: melt if melt-branch solution yields ∂t_V < 0, else freeze.
+    ∂t_Vᵐ   = α + β * ℵᵐ
+    melting = ∂t_Vᵐ < zero(∂t_Vᵐ)
+    ℵtmp    = ifelse(melting, ℵᵐ, ℵᶠ)
+
+    # Final state via `ice_volume_update` (handles V<0 clipping, ridging, etc.).
+    Quie = Qui + Qs * ℵtmp
     ∂t_V = ice_melt_freeze_tendency(i, j, 1, grid,
                                     ice_thermodynamics,
                                     phase_transitions,
                                     sea_ice_density,
-                                    Qi_ice,
+                                    Qii,
                                     Tsi,
                                     ice_thickness, ice_consolidation_thickness,
-                                    Qui_eff, bottom_external_heat_flux,
+                                    Quie, bottom_external_heat_flux,
                                     clock, model_fields)
 
     hiⁿ⁺¹, ℵⁿ⁺¹ = ice_volume_update(ice_thermodynamics, ∂t_V, hiⁿ, ℵⁿ, hᶜ, Δt)
@@ -232,8 +267,7 @@ end
     hs⁺ = hsⁿ + Δt * (Gs⁺ - Gs⁻)
     hs⁺ = max(zero(hs⁺), hs⁺)
 
-    # Snow-ice formation (flooding when freeboard is negative)
-    @inbounds ρi = sea_ice_density[i, j, 1]
+    # Snow-ice formation (flooding when freeboard is negative).
     hiⁿ⁺¹, hs⁺ = snow_ice_formation(hiⁿ⁺¹, hs⁺, ρi, ρs, phase_transitions.liquid_density)
 
     # Reset snow when no ice

--- a/src/SeaIceThermodynamics/thermodynamic_time_step.jl
+++ b/src/SeaIceThermodynamics/thermodynamic_time_step.jl
@@ -8,7 +8,7 @@ using KernelAbstractions: @kernel, @index
 thermodynamic_time_step!(model, ::Nothing, snow_thermodynamics, Δt) = nothing
 
 # Only slab ice
-function thermodynamic_time_step!(model, ::SlabThermodynamics, ::Nothing, Δt)
+function thermodynamic_time_step!(model, ice_thermodynamics::SlabThermodynamics, ::Nothing, Δt)
     grid = model.grid
     arch = architecture(grid)
 
@@ -19,7 +19,9 @@ function thermodynamic_time_step!(model, ::SlabThermodynamics, ::Nothing, Δt)
             grid, Δt,
             model.clock,
             model.ice_consolidation_thickness,
-            model.ice_thermodynamics,
+            ice_thermodynamics,
+            model.phase_transitions,
+            model.ice_density,
             model.external_heat_fluxes.top,
             model.external_heat_fluxes.bottom,
             fields(model))
@@ -28,7 +30,10 @@ function thermodynamic_time_step!(model, ::SlabThermodynamics, ::Nothing, Δt)
 end
 
 # Slab ice and slab snow
-function thermodynamic_time_step!(model, ::SlabThermodynamics, ::SlabThermodynamics, Δt)
+function thermodynamic_time_step!(model,
+                                  ice_thermodynamics::SlabThermodynamics,
+                                  snow_thermodynamics::SlabThermodynamics,
+                                  Δt)
     grid = model.grid
     arch = architecture(grid)
 
@@ -39,11 +44,14 @@ function thermodynamic_time_step!(model, ::SlabThermodynamics, ::SlabThermodynam
             grid, Δt,
             model.clock,
             model.ice_consolidation_thickness,
-            model.ice_thermodynamics,
+            ice_thermodynamics,
+            snow_thermodynamics,
+            model.phase_transitions,
+            model.ice_density,
+            model.snow_density,
             model.external_heat_fluxes.top,
             model.external_heat_fluxes.bottom,
             model.snow_thickness,
-            model.snow_thermodynamics,
             model.snowfall,
             fields(model))
 
@@ -72,6 +80,8 @@ end
                                                clock,
                                                ice_consolidation_thickness,
                                                ice_thermodynamics,
+                                               phase_transitions,
+                                               ice_density,
                                                top_external_heat_flux,
                                                bottom_external_heat_flux,
                                                model_fields)
@@ -84,6 +94,8 @@ end
 
     ∂t_V = thermodynamic_tendency(i, j, 1, grid,
                                   ice_thermodynamics,
+                                  phase_transitions,
+                                  ice_density,
                                   ice_thickness,
                                   ice_concentration,
                                   ice_consolidation_thickness,
@@ -101,25 +113,31 @@ end
 ##### Layered snow + ice thermodynamic kernel
 #####
 
-# When snow is present, it sits on top of ice as an independent layer.
-# The snow layer owns the surface temperature solve using the combined
-# snow+ice conductive flux (IceSnowConductiveFlux). The interface temperature
-# Tsi is computed analytically and written to the ice's top_surface_temperature.
+# When snow is present, it sits on top of ice as an independent layer. The
+# column-top surface solve happens at the atmosphere-snow surface using the
+# combined snow+ice conductive flux (`IceSnowConductiveFlux`). The combined
+# flux is constructed inline from the two layer conductivities; it is not
+# stored on either thermodynamics.
 #
-# Top-down coupling: snow → Tsi → ice. The ice thermodynamics is unchanged.
+# The snow-ice interface temperature Tsi is computed analytically from the
+# resistance ratio and handed to `ice_melt_freeze_tendency` as an argument,
+# so the ice's surface solve is not invoked.
 @kernel function _layered_thermodynamic_time_step!(ice_thickness,
-                                                    ice_concentration,
-                                                    grid,
-                                                    Δt,
-                                                    clock,
-                                                    ice_consolidation_thickness,
-                                                    ice_thermodynamics,
-                                                    top_external_heat_flux,
-                                                    bottom_external_heat_flux,
-                                                    snow_thickness,
-                                                    snow_thermodynamics,
-                                                    snowfall,
-                                                    model_fields)
+                                                   ice_concentration,
+                                                   grid,
+                                                   Δt,
+                                                   clock,
+                                                   ice_consolidation_thickness,
+                                                   ice_thermodynamics,
+                                                   snow_thermodynamics,
+                                                   phase_transitions,
+                                                   ice_density,
+                                                   snow_density,
+                                                   top_external_heat_flux,
+                                                   bottom_external_heat_flux,
+                                                   snow_thickness,
+                                                   snowfall,
+                                                   model_fields)
 
     i, j = @index(Global, NTuple)
 
@@ -130,21 +148,27 @@ end
 
     consolidated_ice = hiⁿ ≥ hᶜ
 
-    phase_ice = ice_thermodynamics.phase_transitions
-    liquidus  = phase_ice.liquidus
+    liquidus = phase_transitions.liquidus
     bottom_bc = ice_thermodynamics.heat_boundary_conditions.bottom
     @inbounds Si = model_fields.S[i, j, 1]
 
     Tb = bottom_temperature(i, j, grid, bottom_bc, liquidus)
     Tm = melting_temperature(liquidus, Si)
 
-    # --- Snow surface solve ---
-    # Snow's internal_heat_flux is a FluxFunction wrapping ice_snow_conductive_flux,
-    # which computes the combined conductive flux F = (Tb - Tu) / (hs/ks + hi/ki).
-    # The MeltingConstrainedFluxBalance root-find balances Qatm(Tu) = Fc(Tu).
+    # --- Snow surface solve using the combined snow+ice conductive flux ---
+    # Resistors in series: F = (Tb - Tu) / (hs/ks + hi/ki). Built inline from
+    # the two layer conductivities using `model.phase_transitions.liquidus`,
+    # so neither slab needs to hold a liquidus reference.
+    ks = snow_thermodynamics.internal_heat_flux.conductivity
+    ki = ice_thermodynamics.internal_heat_flux.conductivity
+    combined_flux = IceSnowConductiveFlux(ks, ki)
+    Qi_column = internal_flux_function(combined_flux, liquidus, bottom_bc)
+
+    # Ice-only flux wrapper for the ice-interior evaluation at Tsi.
+    Qi_ice = internal_flux_function(ice_thermodynamics.internal_heat_flux, liquidus, bottom_bc)
+
     snow_top_bc = snow_thermodynamics.heat_boundary_conditions.top
     Tu = snow_thermodynamics.top_surface_temperature
-    Qi = snow_thermodynamics.internal_heat_flux
     Qu = top_external_heat_flux
 
     # Effective melting temperature: snow (0 C) when snow present, ice otherwise
@@ -152,8 +176,8 @@ end
 
     if !isa(snow_top_bc, PrescribedTemperature)
         if consolidated_ice
-            Tu⁻ = @inbounds Tu[i, j, 1]
-            Tuⁿ = top_surface_temperature(i, j, grid, snow_top_bc, Tu⁻, Qi, Qu, clock, model_fields)
+            @inbounds Tu⁻ = Tu[i, j, 1]
+            Tuⁿ = top_surface_temperature(i, j, grid, snow_top_bc, Tu⁻, Qi_column, Qu, clock, model_fields)
             Tuⁿ = min(Tuⁿ, Tm)
         else
             Tuⁿ = Tb
@@ -165,42 +189,38 @@ end
 
     # Tsi = Tb + (Tus - Tb) * Ri / (Rs + Ri)
     # When hs = 0: Tsi = Tus (snow layer has zero resistance)
-    snow_params = snow_thermodynamics.internal_heat_flux.parameters
-    flux     = snow_params.flux
-    liquidus = snow_params.liquidus
-    bottom_bc = snow_params.bottom_heat_boundary_condition
-    Tsi = interface_temperature(i, j, grid, flux, bottom_bc, liquidus, Tus, model_fields)
-    @inbounds ice_thermodynamics.top_surface_temperature[i, j, 1] = Tsi
+    Tsi = interface_temperature(i, j, grid, combined_flux, bottom_bc, liquidus, Tus, model_fields)
 
-    Qis = ifelse(consolidated_ice, getflux(Qi, i, j, grid, Tus, clock, model_fields), zero(grid))
+    # Snow surface melt energy (uses ℒ₀ since the surface solve caps Tus at 0 C)
+    Qis = ifelse(consolidated_ice, getflux(Qi_column, i, j, grid, Tus, clock, model_fields), zero(grid))
     Qui = getflux(Qu, i, j, grid, Tus, clock, model_fields)
 
     # δQ < 0 means more internal flux than external → energy available for melting
     δQ = Qui - Qis
     melt_energy = max(zero(δQ), -δQ) # positive when melting
 
-    ρs = snow_thermodynamics.phase_transitions.density
-    ℒs = snow_thermodynamics.phase_transitions.reference_latent_heat
+    @inbounds ρs = snow_density[i, j, 1]
+    ℒs = phase_transitions.reference_latent_heat
 
     snow_energy_capacity = ρs * ℒs * hsⁿ / Δt # W/m²
-    Qs  = min(melt_energy, snow_energy_capacity)
+    Qs = min(melt_energy, snow_energy_capacity)
     Gs⁻ = Qs / (ρs * ℒs)
 
-    # The effective top flux for the ice is Qui + snow_absorbed.
+    # The effective top flux for the ice is Qui + Qs.
     # Snow absorbing melt energy acts as extra cooling from the ice's perspective:
-    # thermodynamic_tendency computes Qi = Qis (by interface temperature construction),
-    # so  wu = (Qui + Qs - Qis) / ℰu = - Qs / ℰu
-    # and wb = (Qis - Qb) / ℰb.
-    Qui = Qui + Qs
+    # the ice-interior flux is evaluated at Tsi, so  wu = (Qui + Qs - Qii) / ℰu
+    # and wb = (Qii - Qb) / ℰb.
+    Qui_eff = Qui + Qs
 
-    ∂t_V = thermodynamic_tendency(i, j, 1, grid,
-                                  ice_thermodynamics,
-                                  ice_thickness,
-                                  ice_concentration,
-                                  ice_consolidation_thickness,
-                                  Qui,
-                                  bottom_external_heat_flux,
-                                  clock, model_fields)
+    ∂t_V = ice_melt_freeze_tendency(i, j, 1, grid,
+                                    ice_thermodynamics,
+                                    phase_transitions,
+                                    ice_density,
+                                    Qi_ice,
+                                    Tsi,
+                                    ice_thickness, ice_consolidation_thickness,
+                                    Qui_eff, bottom_external_heat_flux,
+                                    clock, model_fields)
 
     hiⁿ⁺¹, ℵⁿ⁺¹ = ice_volume_update(ice_thermodynamics, ∂t_V, hiⁿ, ℵⁿ, hᶜ, Δt)
 
@@ -208,12 +228,13 @@ end
     # so hs adjusts to keep hs * ℵ constant (analogous to how ice tracks hi * ℵ).
     hsⁿ = ifelse(ℵⁿ⁺¹ > 0, hsⁿ * ℵⁿ / ℵⁿ⁺¹, zero(hsⁿ))
 
-    Gs⁺ = snow_accumulation(i, j, snowfall, snow_thermodynamics, ℵⁿ⁺¹, clock)
-    hs⁺  = hsⁿ + Δt * (Gs⁺ - Gs⁻)
-    hs⁺  = max(zero(hs⁺), hs⁺)
+    Gs⁺ = snow_accumulation(i, j, snowfall, ρs, ℵⁿ⁺¹, clock)
+    hs⁺ = hsⁿ + Δt * (Gs⁺ - Gs⁻)
+    hs⁺ = max(zero(hs⁺), hs⁺)
 
     # Snow-ice formation (flooding when freeboard is negative)
-    hiⁿ⁺¹, hs⁺ = snow_ice_formation(hiⁿ⁺¹, hs⁺, ice_thermodynamics, snow_thermodynamics)
+    @inbounds ρi = ice_density[i, j, 1]
+    hiⁿ⁺¹, hs⁺ = snow_ice_formation(hiⁿ⁺¹, hs⁺, ρi, ρs, phase_transitions.liquid_density)
 
     # Reset snow when no ice
     hs⁺ = ifelse(ℵⁿ⁺¹ ≤ 0, zero(hs⁺), hs⁺)
@@ -254,23 +275,18 @@ const FTS = Union{FieldTimeSeries, GPUAdaptedFieldTimeSeries}
 @inline get_precipitation(i, j, Ps, clock)      = @inbounds Ps[i, j, 1]
 @inline get_precipitation(i, j, Ps::FTS, clock) = @inbounds Ps[i, j, 1, Time(clock.time)]
 
-@inline function snow_accumulation(i, j, snowfall, snow_thermo, ℵ, clock)
-    Ps = get_precipitation(i, j, snowfall, clock) # kg/m^2/s
-    ρs = snow_thermo.phase_transitions.density
+@inline function snow_accumulation(i, j, snowfall, ρs, ℵ, clock)
+    Ps = get_precipitation(i, j, snowfall, clock) # kg m⁻² s⁻¹
     return ifelse(ℵ > 0, Ps / ρs, zero(ρs))
 end
 
-@inline function snow_ice_formation(hi, hs, ice_thermo, snow_thermo)
-    ρi = ice_thermo.phase_transitions.density
-    ρs = snow_thermo.phase_transitions.density
-    ρw = ice_thermo.phase_transitions.liquid_density
-
+@inline function snow_ice_formation(hi, hs, ρi, ρs, ρw)
     # Freeboard: positive when ice floats above waterline
     hf = hi * (1 - ρi / ρw) - hs * ρs / ρw
 
     # Flooding occurs when freeboard is negative.
     # Mass conservation (δhi ρi = δhs ρs) also conserves energy
-    # since ℰ = ρ L (see `latent_heat`) and L is the same for ice and snow.
+    # since the per-mass latent heat is shared between snow and ice.
     flooding = hf < 0
     δhs = ifelse(flooding, -hf * ρi / ρs, zero(hf))
 

--- a/src/SeaIceThermodynamics/thermodynamic_time_step.jl
+++ b/src/SeaIceThermodynamics/thermodynamic_time_step.jl
@@ -21,7 +21,7 @@ function thermodynamic_time_step!(model, ice_thermodynamics::SlabThermodynamics,
             model.ice_consolidation_thickness,
             ice_thermodynamics,
             model.phase_transitions,
-            model.ice_density,
+            model.sea_ice_density,
             model.external_heat_fluxes.top,
             model.external_heat_fluxes.bottom,
             fields(model))
@@ -47,7 +47,7 @@ function thermodynamic_time_step!(model,
             ice_thermodynamics,
             snow_thermodynamics,
             model.phase_transitions,
-            model.ice_density,
+            model.sea_ice_density,
             model.snow_density,
             model.external_heat_fluxes.top,
             model.external_heat_fluxes.bottom,
@@ -81,7 +81,7 @@ end
                                                ice_consolidation_thickness,
                                                ice_thermodynamics,
                                                phase_transitions,
-                                               ice_density,
+                                               sea_ice_density,
                                                top_external_heat_flux,
                                                bottom_external_heat_flux,
                                                model_fields)
@@ -95,7 +95,7 @@ end
     ∂t_V = thermodynamic_tendency(i, j, 1, grid,
                                   ice_thermodynamics,
                                   phase_transitions,
-                                  ice_density,
+                                  sea_ice_density,
                                   ice_thickness,
                                   ice_concentration,
                                   ice_consolidation_thickness,
@@ -131,7 +131,7 @@ end
                                                    ice_thermodynamics,
                                                    snow_thermodynamics,
                                                    phase_transitions,
-                                                   ice_density,
+                                                   sea_ice_density,
                                                    snow_density,
                                                    top_external_heat_flux,
                                                    bottom_external_heat_flux,
@@ -215,7 +215,7 @@ end
     ∂t_V = ice_melt_freeze_tendency(i, j, 1, grid,
                                     ice_thermodynamics,
                                     phase_transitions,
-                                    ice_density,
+                                    sea_ice_density,
                                     Qi_ice,
                                     Tsi,
                                     ice_thickness, ice_consolidation_thickness,
@@ -233,7 +233,7 @@ end
     hs⁺ = max(zero(hs⁺), hs⁺)
 
     # Snow-ice formation (flooding when freeboard is negative)
-    @inbounds ρi = ice_density[i, j, 1]
+    @inbounds ρi = sea_ice_density[i, j, 1]
     hiⁿ⁺¹, hs⁺ = snow_ice_formation(hiⁿ⁺¹, hs⁺, ρi, ρs, phase_transitions.liquid_density)
 
     # Reset snow when no ice

--- a/src/SeaIceThermodynamics/thermodynamic_time_step.jl
+++ b/src/SeaIceThermodynamics/thermodynamic_time_step.jl
@@ -115,9 +115,7 @@ end
 
 # When snow is present, it sits on top of ice as an independent layer. The
 # column-top surface solve happens at the atmosphere-snow surface using the
-# combined snow+ice conductive flux (`IceSnowConductiveFlux`). The combined
-# flux is constructed inline from the two layer conductivities; it is not
-# stored on either thermodynamics.
+# combined snow+ice conductive flux (`IceSnowConductiveFlux`). 
 #
 # The snow-ice interface temperature Tsi is computed analytically from the
 # resistance ratio and handed to `ice_melt_freeze_tendency` as an argument,
@@ -155,10 +153,8 @@ end
     Tb = bottom_temperature(i, j, grid, bottom_bc, liquidus)
     Tm = melting_temperature(liquidus, Si)
 
-    # --- Snow surface solve using the combined snow+ice conductive flux ---
-    # Resistors in series: F = (Tb - Tu) / (hs/ks + hi/ki). Built inline from
-    # the two layer conductivities using `model.phase_transitions.liquidus`,
-    # so neither slab needs to hold a liquidus reference.
+    # Snow surface solve using the combined snow+ice conductive flux with a 
+    # resistors in series formulation: F = (Tb - Tu) / (hs/ks + hi/ki). 
     ks = snow_thermodynamics.internal_heat_flux.conductivity
     ki = ice_thermodynamics.internal_heat_flux.conductivity
     combined_flux = IceSnowConductiveFlux(ks, ki)
@@ -194,9 +190,7 @@ end
     Tsi = interface_temperature(i, j, grid, combined_flux, bottom_bc, liquidus, Tus, model_fields)
 
     # Snow-surface energy balance (Qis per-ice column flux, Qui per-cell from
-    # the coupler). Compare like with like by converting Qui to per-ice;
-    # Qui/ℵⁿ = Qui when ℵⁿ = 1, and restores the correct per-ice driving
-    # flux when ℵⁿ < 1.
+    # the coupler). Converting Qui to per-ice...
     Qis = ifelse(consolidated_ice, getflux(Qic, i, j, grid, Tus, clock, model_fields), zero(grid))
     Qui = getflux(Qu, i, j, grid, Tus, clock, model_fields)
 
@@ -220,8 +214,7 @@ end
     #   C = ℵⁿ/(2hⁿ) (melt)  or  (1−ℵⁿ)/hᶜ (freeze)
     # has the explicit solution  ℵⁿ⁺¹ = (ℵⁿ + K·α) / (1 − K·β).
     # Solve both branches and pick the one with sign(∂t_V(ℵⁿ⁺¹)) consistent
-    # with its branch assumption. |K·β| ≲ 10⁻⁶ at ocean scales so the denominators are
-    # safely away from zero in practice; all divisions are NaN-guarded.
+    # with its branch assumption.
     @inbounds ρi = sea_ice_density[i, j, 1]
     ρiℒ = ρi * ℒs
     Qbi = getflux(bottom_external_heat_flux, i, j, grid, Tus, clock, model_fields)

--- a/src/SeaIceThermodynamics/thermodynamic_time_step.jl
+++ b/src/SeaIceThermodynamics/thermodynamic_time_step.jl
@@ -207,7 +207,7 @@ end
     Gs⁻ = Qs / (ρs * ℒs)                         # per-ice, drives Δhs
 
     # Closed-form self-consistent solve for ℵⁿ⁺¹. The ice-top effective flux
-    # Quie = Qui + Qs·ℵⁿ⁺¹ couples Quie and ℵⁿ⁺¹ linearly; the slab's
+    # Quiᵉᶠᶠ = Qui + Qs·ℵⁿ⁺¹ couples Quiᵉᶠᶠ and ℵⁿ⁺¹ linearly; the slab's
     # concentration rule is also linear in ∂t_V, so the fixed point
     #   ∂t_V = α + β·ℵⁿ⁺¹,    α = (Qui − Qbi)/(ρᵢℒ),  β = Qs/(ρᵢℒ)
     #   ℵⁿ⁺¹ = ℵⁿ + K·∂t_V,   K = Δt · C,
@@ -240,7 +240,7 @@ end
 
     # Final state via `ice_volume_update` (handles V<0 clipping, ridging, etc.).
     # Pass the cached Qbi scalar (not the closure) so the bottom-flux closure is evaluated exactly once per step
-    Quie = Qui + Qs * ℵtmp
+    Quiᵉᶠᶠ = Qui + Qs * ℵtmp
     ∂t_V = ice_melt_freeze_tendency(i, j, 1, grid,
                                     ice_thermodynamics,
                                     phase_transitions,
@@ -248,7 +248,7 @@ end
                                     Qii,
                                     Tsi,
                                     ice_thickness, ice_consolidation_thickness,
-                                    Quie, Qbi,
+                                    Quiᵉᶠᶠ, Qbi,
                                     clock, model_fields)
 
     hiⁿ⁺¹, ℵⁿ⁺¹ = ice_volume_update(ice_thermodynamics, ∂t_V, hiⁿ, ℵⁿ, hᶜ, Δt)

--- a/src/sea_ice_model.jl
+++ b/src/sea_ice_model.jl
@@ -12,7 +12,8 @@ using Oceananigans.OutputReaders: FieldTimeSeries
 using Oceananigans.TimeSteppers: TimeStepper
 
 using ClimaSeaIce.SeaIceDynamics: ExtendedSplitExplicitMomentumEquation
-using ClimaSeaIce.SeaIceThermodynamics: PrescribedTemperature, FluxFunction, IceSnowConductiveFlux
+using ClimaSeaIce.SeaIceThermodynamics: PrescribedTemperature, FluxFunction, IceSnowConductiveFlux,
+                                        PhaseTransitions, internal_flux_function
 using ClimaSeaIce.SeaIceThermodynamics.HeatBoundaryConditions: flux_summary
 
 import Oceananigans.Architectures: architecture
@@ -27,7 +28,7 @@ const ConnectedTopology = Union{LeftConnected, RightConnected, FullyConnected,
                                 LeftConnectedRightCenterFolded, LeftConnectedRightFaceFolded,
                                 LeftConnectedRightCenterConnected, LeftConnectedRightFaceConnected}
 
-struct SeaIceModel{GR, TD, SNT, D, TS, CL, U, T, IT, IC, SNH, ID, CT, SP, STF, A, F, Arch} <: AbstractModel{TS, Arch}
+struct SeaIceModel{GR, TD, SNT, D, TS, CL, U, T, IT, IC, SNH, ID, SND, PT, CT, SP, STF, A, F, Arch} <: AbstractModel{TS, Arch}
     architecture :: Arch
     grid :: GR
     clock :: CL
@@ -39,7 +40,10 @@ struct SeaIceModel{GR, TD, SNT, D, TS, CL, U, T, IT, IC, SNH, ID, CT, SP, STF, A
     ice_concentration :: IC
     snow_thickness :: SNH
     ice_density :: ID
+    snow_density :: SND
     ice_consolidation_thickness :: CT
+    # Shared thermodynamic parameters
+    phase_transitions :: PT
     # Thermodynamics
     ice_thermodynamics :: TD
     snow_thermodynamics :: SNT
@@ -61,7 +65,9 @@ function SeaIceModel(grid;
                      clock                       = Clock{eltype(grid)}(time = 0),
                      ice_consolidation_thickness = 0.05, # m
                      ice_salinity                = 0, # psu
-                     ice_density                 = 900, # kg m⁻³
+                     ice_density                 = 900, # kg m⁻³, bulk sea-ice
+                     snow_density                = 330, # kg m⁻³, bulk snow
+                     phase_transitions           = PhaseTransitions(eltype(grid)),
                      top_heat_flux               = nothing,
                      bottom_heat_flux            = 0,
                      velocities                  = nothing,
@@ -125,6 +131,7 @@ function SeaIceModel(grid;
     # Wrap ice_salinity in a field
     ice_salinity = field((Center, Center, Nothing), ice_salinity, grid)
     ice_density  = field((Center, Center, Nothing), ice_density, grid)
+    snow_density = field((Center, Center, Nothing), snow_density, grid)
 
     # Construct prognostic fields if not provided
     ice_thickness = Field{Center, Center, Nothing}(grid, boundary_conditions=boundary_conditions.h)
@@ -165,50 +172,15 @@ function SeaIceModel(grid;
     tracers = merge(tracers, (; S = ice_salinity))
     timestepper = TimeStepper(timestepper, grid, prognostic_fields)
 
-    # When snow is present:
-    # 1. Rebuild snow thermodynamics with IceSnowConductiveFlux so the snow's
-    #    surface solve uses the combined resistance (hs/ks + hi/ki).
-    # 2. Set ice's top BC to PrescribedTemperature so thermodynamic_tendency
-    #    skips the surface solve (the layered kernel prescribes Tsi).
-    # 3. Ensure ice's top_surface_temperature is a writable Field.
-    if !isnothing(snow_thermodynamics) && !isnothing(ice_thermodynamics)
-        # Ensure ice's top_surface_temperature is writable
-        Tu_ice = ice_thermodynamics.top_surface_temperature
-        if Tu_ice isa ConstantField
-            Tu_ice = Field{Center, Center, Nothing}(grid)
-            set!(Tu_ice, ice_thermodynamics.top_surface_temperature.constant)
-        end
-
-        # Ice gets PrescribedTemperature BC: the layered kernel writes Tsi,
-        # then delegates to thermodynamic_tendency which skips the surface solve.
-        ice_thermodynamics = SlabThermodynamics(grid;
-            top_surface_temperature        = Tu_ice,
-            top_heat_boundary_condition    = PrescribedTemperature(0),
-            bottom_heat_boundary_condition = ice_thermodynamics.heat_boundary_conditions.bottom,
-            internal_heat_flux             = ice_thermodynamics.internal_heat_flux.parameters.flux,
-            phase_transitions              = ice_thermodynamics.phase_transitions,
-            concentration_evolution        = ice_thermodynamics.concentration_evolution)
-
-        # Build combined snow+ice conductive flux
-        ks = snow_thermodynamics.internal_heat_flux.parameters.flux.conductivity
-        ki = ice_thermodynamics.internal_heat_flux.parameters.flux.conductivity
-        combined_flux = IceSnowConductiveFlux(ks, ki)
-
-        snow_thermodynamics = SlabThermodynamics(grid;
-            top_surface_temperature        = snow_thermodynamics.top_surface_temperature,
-            top_heat_boundary_condition    = snow_thermodynamics.heat_boundary_conditions.top,
-            bottom_heat_boundary_condition = ice_thermodynamics.heat_boundary_conditions.bottom,
-            internal_heat_flux             = combined_flux,
-            phase_transitions              = snow_thermodynamics.phase_transitions,
-            concentration_evolution        = snow_thermodynamics.concentration_evolution)
-    end
-
     if !isnothing(ice_thermodynamics)
         if isnothing(top_heat_flux)
             if isnothing(snow_thermodynamics) &&
                ice_thermodynamics.heat_boundary_conditions.top isa PrescribedTemperature
-                # Default: external top flux is in equilibrium with internal fluxes
-                top_heat_flux = ice_thermodynamics.internal_heat_flux
+                # Default: external top flux is in equilibrium with internal fluxes.
+                # Build a FluxFunction wrapper using the model's shared liquidus.
+                top_heat_flux = internal_flux_function(ice_thermodynamics.internal_heat_flux,
+                                                       phase_transitions.liquidus,
+                                                       ice_thermodynamics.heat_boundary_conditions.bottom)
             else
                 # Default: no external top surface flux
                 top_heat_flux = 0
@@ -235,7 +207,9 @@ function SeaIceModel(grid;
                        ice_concentration,
                        snow_thickness,
                        ice_density,
+                       snow_density,
                        ice_consolidation_thickness,
+                       phase_transitions,
                        ice_thermodynamics,
                        snow_thermodynamics,
                        dynamics,
@@ -297,7 +271,8 @@ snow_fields(::Nothing) = NamedTuple()
 snow_fields(hs) = (; hs)
 
 fields(model::SIM) = merge((; h  = model.ice_thickness,
-                              ℵ  = model.ice_concentration),
+                              ℵ  = model.ice_concentration,
+                              ρi = model.ice_density),
                            snow_fields(model.snow_thickness),
                            model.tracers,
                            model.velocities,
@@ -351,6 +326,7 @@ function prognostic_state(model::SeaIceModel)
             tracers = prognostic_state(model.tracers),
             timestepper = prognostic_state(model.timestepper),
             ice_thermodynamics = prognostic_state(model.ice_thermodynamics),
+            snow_thermodynamics = prognostic_state(model.snow_thermodynamics),
             dynamics = prognostic_state(model.dynamics))
 end
 
@@ -363,6 +339,7 @@ function restore_prognostic_state!(model::SeaIceModel, state)
     restore_prognostic_state!(model.tracers, state.tracers)
     restore_prognostic_state!(model.timestepper, state.timestepper)
     restore_prognostic_state!(model.ice_thermodynamics, state.ice_thermodynamics)
+    restore_prognostic_state!(model.snow_thermodynamics, state.snow_thermodynamics)
     restore_prognostic_state!(model.dynamics, state.dynamics)
     return model
 end

--- a/src/sea_ice_model.jl
+++ b/src/sea_ice_model.jl
@@ -40,7 +40,7 @@ struct SeaIceModel{GR, TD, SNT, D, TS, CL, U, T, IT, IC, SNH, ID, SND, PT, CT, S
     ice_thickness :: IT
     ice_concentration :: IC
     snow_thickness :: SNH
-    ice_density :: ID
+    sea_ice_density :: ID
     snow_density :: SND
     ice_consolidation_thickness :: CT
     # Shared thermodynamic parameters
@@ -66,7 +66,7 @@ function SeaIceModel(grid;
                      clock                       = Clock{eltype(grid)}(time = 0),
                      ice_consolidation_thickness = 0.05, # m
                      ice_salinity                = 0, # psu
-                     ice_density                 = 900, # kg m⁻³, bulk sea-ice
+                     sea_ice_density             = 900, # kg m⁻³, bulk sea-ice
                      snow_density                = 330, # kg m⁻³, bulk snow
                      phase_transitions           = PhaseTransitions(eltype(grid)),
                      top_heat_flux               = nothing,
@@ -130,9 +130,9 @@ function SeaIceModel(grid;
 
     # TODO: pass `clock` into `field`, so functions can be time-dependent?
     # Wrap ice_salinity in a field
-    ice_salinity = field((Center, Center, Nothing), ice_salinity, grid)
-    ice_density  = field((Center, Center, Nothing), ice_density, grid)
-    snow_density = field((Center, Center, Nothing), snow_density, grid)
+    ice_salinity    = field((Center, Center, Nothing), ice_salinity, grid)
+    sea_ice_density = field((Center, Center, Nothing), sea_ice_density, grid)
+    snow_density    = field((Center, Center, Nothing), snow_density, grid)
 
     # Construct prognostic fields if not provided
     ice_thickness = Field{Center, Center, Nothing}(grid, boundary_conditions=boundary_conditions.h)
@@ -211,7 +211,7 @@ function SeaIceModel(grid;
                        ice_thickness,
                        ice_concentration,
                        snow_thickness,
-                       ice_density,
+                       sea_ice_density,
                        snow_density,
                        ice_consolidation_thickness,
                        phase_transitions,
@@ -277,7 +277,7 @@ snow_fields(hs) = (; hs)
 
 fields(model::SIM) = merge((; h  = model.ice_thickness,
                               ℵ  = model.ice_concentration,
-                              ρi = model.ice_density),
+                              ρi = model.sea_ice_density),
                            snow_fields(model.snow_thickness),
                            model.tracers,
                            model.velocities,

--- a/test/test_energy_conservation.jl
+++ b/test/test_energy_conservation.jl
@@ -47,7 +47,7 @@ function energy_conservation_test(; snow=false, precipitation=false, melting=fal
 
     pt = model.phase_transitions
     ℒ  = latent_heat(pt, 0)                    # per-mass at 0 ᵒC
-    ρi = @inbounds model.ice_density[1, 1, 1]  # bulk ice density
+    ρi = @inbounds model.sea_ice_density[1, 1, 1]  # bulk sea-ice density
     ρs = snow ? @inbounds(model.snow_density[1, 1, 1]) : 0.0
 
     Δt = 600.0

--- a/test/test_energy_conservation.jl
+++ b/test/test_energy_conservation.jl
@@ -1,5 +1,5 @@
 using ClimaSeaIce
-using ClimaSeaIce.SeaIceThermodynamics: latent_heat
+using ClimaSeaIce.SeaIceThermodynamics: latent_heat, bottom_temperature
 using ClimaSeaIce.SeaIceThermodynamics.HeatBoundaryConditions: FluxFunction
 using Oceananigans
 using Oceananigans.Fields: interior
@@ -108,5 +108,104 @@ end
 
     @testset "Snow with precipitation, melting" begin
         @test energy_conservation_test(snow=true, precipitation=true, melting=true) < rtol
+    end
+end
+
+# The tests above run with ℵ = 1 throughout, which hides a per-cell /
+# per-ice convention inconsistency in the layered snow-ice kernel (the
+# snow-surface energy balance compared per-cell atmospheric flux with the
+# per-ice conductive flux, under-estimating snow melt when ℵ < 1). The
+# tests below exercise ℵ < 1 to catch regressions on that fix. They use
+# a per-cell top heat flux (consistent with what `_layered_thermodynamic_time_step!`
+# actually expects after the upstream NumericalEarth assembler fix).
+
+@inline function recording_per_cell_flux(i, j, grid, Tu, clock, fields, p)
+    ℵ = fields.ℵ[i, j, 1]
+    # Per-ice flux times ℵ → per-cell (mirrors what the coupled assembler writes)
+    Q_per_ice = p.coefficient * (Tu - p.temperature)
+    Q         = Q_per_ice * ℵ
+    p.record[1] = Q
+    return Q
+end
+
+function partial_cover_energy_conservation_test(; ℵ₀ = 0.5, hs₀ = 0.15, melting = true)
+    grid = RectilinearGrid(size=(), topology=(Flat, Flat, Flat))
+
+    Ta = melting ? 5.0 : -15.0
+    top_record = [0.0]
+    top_params = (coefficient = 1e-3 * 1.225 * 1004 * 5, temperature = Ta, record = top_record)
+    top_heat_flux = FluxFunction(recording_per_cell_flux; parameters = top_params)
+
+    Qb = melting ? -20.0 : -5.0
+    bot_record = [0.0]
+    bot_heat_flux = FluxFunction(bottom_recording_flux; parameters = (flux_value = Qb, record = bot_record))
+
+    snow_thermo = snow_slab_thermodynamics(grid)
+
+    model = SeaIceModel(grid;
+                        ice_consolidation_thickness = 0.05,
+                        top_heat_flux,
+                        bottom_heat_flux = bot_heat_flux,
+                        snow_thermodynamics = snow_thermo,
+                        snowfall = 0)
+
+    set!(model, h = 1.0, ℵ = ℵ₀, hs = hs₀)
+
+    pt = model.phase_transitions
+    ℒ  = latent_heat(pt, 0)
+    ρi = @inbounds model.sea_ice_density[1, 1, 1]
+    ρs = @inbounds model.snow_density[1, 1, 1]
+
+    Δt = 600.0
+    Nsteps = 200
+    max_residual = 0.0
+
+    for n in 1:Nsteps
+        h₀  = first(interior(model.ice_thickness))
+        ℵ₀_ = first(interior(model.ice_concentration))
+        hs₀_ = first(interior(model.snow_thickness))
+        E₀  = -ℵ₀_ * (ρi * ℒ * h₀ + ρs * ℒ * hs₀_)
+
+        time_step!(model, Δt)
+
+        h₁  = first(interior(model.ice_thickness))
+        ℵ₁  = first(interior(model.ice_concentration))
+        hs₁ = first(interior(model.snow_thickness))
+        E₁  = -ℵ₁ * (ρi * ℒ * h₁ + ρs * ℒ * hs₁)
+
+        Qa = top_record[1]            # per-cell (mirrors coupler output)
+        Ql = bot_record[1]            # per-cell bottom
+
+        dE       = E₁ - E₀
+        expected = (-Qa + Ql) * Δt
+        scale    = max(abs(E₀), abs(E₁), abs(expected), 1.0)
+        residual = abs(dE - expected) / scale
+        max_residual = max(max_residual, residual)
+
+        h₁ ≤ 0 && ℵ₁ ≤ 0 && break
+    end
+
+    return max_residual
+end
+
+@testset "Energy conservation with partial ice cover (ℵ < 1)" begin
+    # The closed-form solve in `_layered_thermodynamic_time_step!` is
+    # self-consistent to floating-point precision, so the per-step
+    # energy residual is at round-off. Use a conservative rtol that
+    # still catches the O(1-ℵ) per-cell/per-ice bug (~1e-4 before the
+    # fix) but allows room for floating-point accumulation over many
+    # steps.
+    rtol = 1e-13
+
+    @testset "ℵ = 0.5, snow-covered melting" begin
+        @test partial_cover_energy_conservation_test(ℵ₀=0.5, hs₀=0.15, melting=true) < rtol
+    end
+
+    @testset "ℵ = 0.8, snow-covered melting" begin
+        @test partial_cover_energy_conservation_test(ℵ₀=0.8, hs₀=0.15, melting=true) < rtol
+    end
+
+    @testset "ℵ = 0.3, snow-covered freezing" begin
+        @test partial_cover_energy_conservation_test(ℵ₀=0.3, hs₀=0.05, melting=false) < rtol
     end
 end

--- a/test/test_energy_conservation.jl
+++ b/test/test_energy_conservation.jl
@@ -45,10 +45,10 @@ function energy_conservation_test(; snow=false, precipitation=false, melting=fal
         set!(model, h=1.0, ℵ=1)
     end
 
-    PT = model.ice_thermodynamics.phase_transitions
-    ℰ  = latent_heat(PT, 0)
-    ρs = snow ? snow_thermo.phase_transitions.density : 0.0
-    ℒs = snow ? snow_thermo.phase_transitions.reference_latent_heat : 0.0
+    pt = model.phase_transitions
+    ℒ  = latent_heat(pt, 0)                    # per-mass at 0 ᵒC
+    ρi = @inbounds model.ice_density[1, 1, 1]  # bulk ice density
+    ρs = snow ? @inbounds(model.snow_density[1, 1, 1]) : 0.0
 
     Δt = 600.0
     Nsteps = 200
@@ -58,18 +58,18 @@ function energy_conservation_test(; snow=false, precipitation=false, melting=fal
         h₀  = first(interior(model.ice_thickness))
         ℵ₀  = first(interior(model.ice_concentration))
         hs₀ = snow ? first(interior(model.snow_thickness)) : 0.0
-        E₀  = -ℵ₀ * (ℰ * h₀ + ρs * ℒs * hs₀)
+        E₀  = -ℵ₀ * (ρi * ℒ * h₀ + ρs * ℒ * hs₀)
 
         time_step!(model, Δt)
 
         h₁  = first(interior(model.ice_thickness))
         ℵ₁  = first(interior(model.ice_concentration))
         hs₁ = snow ? first(interior(model.snow_thickness)) : 0.0
-        E₁  = -ℵ₁ * (ℰ * h₁ + ρs * ℒs * hs₁)
+        E₁  = -ℵ₁ * (ρi * ℒ * h₁ + ρs * ℒ * hs₁)
 
         Qa = top_record[1]
         Ql = bot_record[1]
-        Qp = (precipitation && ℵ₁ > 0) ? -ℒs * Ps : 0.0
+        Qp = (precipitation && ℵ₁ > 0) ? -ℒ * Ps : 0.0
 
         dE = E₁ - E₀
         expected = (-Qa + Ql + Qp) * Δt

--- a/test/test_snow_thermodynamics.jl
+++ b/test/test_snow_thermodynamics.jl
@@ -16,14 +16,15 @@ using Test
     @test model.snow_thermodynamics isa SlabThermodynamics
     @test model.snow_thickness isa Field
 
-    # Snow's internal heat flux should be IceSnowConductiveFlux after constructor wiring
+    # Both layers store the raw conductive-flux coefficient; the combined
+    # snow+ice flux (IceSnowConductiveFlux) is assembled inline in the
+    # layered kernel, not stored on the thermodynamics.
     snow_flux = model.snow_thermodynamics.internal_heat_flux
-    @test snow_flux isa FluxFunction
-    @test snow_flux.func === ice_snow_conductive_flux
+    @test snow_flux isa ConductiveFlux
+    @test snow_flux.conductivity ≈ 0.31
 
-    # Ice thermodynamics is untouched (no snow reference)
     ice_flux = model.ice_thermodynamics.internal_heat_flux
-    @test ice_flux isa FluxFunction
+    @test ice_flux isa ConductiveFlux
 
     # Model without snow
     model_no_snow = SeaIceModel(grid)
@@ -126,7 +127,7 @@ end
     snow_thermo = snow_slab_thermodynamics(grid)
     ice_thermo  = SlabThermodynamics(grid)
 
-    Ps = 1e-5  # kg/m^2/s snowfall rate
+    Ps = 1e-5  # kg/m²/s snowfall rate
     model = SeaIceModel(grid;
                         ice_thermodynamics = ice_thermo,
                         snow_thermodynamics = snow_thermo,
@@ -146,15 +147,14 @@ end
     grid = RectilinearGrid(size=(), topology=(Flat, Flat, Flat))
 
     snow_thermo = snow_slab_thermodynamics(grid)
-
-    ice_thermo = SlabThermodynamics(grid)
+    ice_thermo  = SlabThermodynamics(grid)
 
     # Negative top_heat_flux means incoming heat (solar radiation), which
     # drives the surface to the melting point and creates a flux imbalance.
     model = SeaIceModel(grid;
                         ice_thermodynamics = ice_thermo,
                         snow_thermodynamics = snow_thermo,
-                        top_heat_flux = -100) # W/m^2 incoming
+                        top_heat_flux = -100) # W/m² incoming
 
     hi = 2.0
     hs = 0.1
@@ -172,13 +172,11 @@ end
     for timestepper in (:ForwardEuler, :SplitRungeKutta3)
         grid = RectilinearGrid(size=(10, 10), x=(0, 1), y=(0, 1), topology=(Bounded, Bounded, Flat))
 
-        snow_thermo = SlabThermodynamics(grid;
-            internal_heat_flux = ConductiveFlux(conductivity=0.31),
-            phase_transitions = PhaseTransitions(Float64; density=330, heat_capacity=2090,
-                                                 reference_latent_heat=334e3))
+        snow_thermo = snow_slab_thermodynamics(grid)
 
         model = SeaIceModel(grid;
             snow_thermodynamics = snow_thermo,
+            snow_density = 330,
             advection = WENO(),
             timestepper)
 

--- a/test/test_time_stepping.jl
+++ b/test/test_time_stepping.jl
@@ -27,7 +27,7 @@ end
         rheologies = (ElastoViscoPlasticRheology(), ViscousRheology(ν=1000))
         advections = (WENO(), UpwindBiased(order=5))
 
-        ice_thermodynamics = (nothing, SlabThermodynamics(grid))
+        ice_thermodynamics_options = (nothing, SlabThermodynamics(grid))
         snow_thermodynamics_options = (nothing, snow_slab_thermodynamics(grid))
 
         coriolises = (nothing, FPlane(latitude=45), BetaPlane(latitude=45))
@@ -36,7 +36,7 @@ end
         for coriolis in coriolises,
             advection in advections,
             rheology in rheologies,
-            ice_thermo in ice_thermodynamics,
+            ice_thermo in ice_thermodynamics_options,
             snow_thermo in snow_thermodynamics_options,
             solver in solvers
 


### PR DESCRIPTION
A (Very substantial!!) refactor. Closes #133.

## Summary

Reorganises the thermodynamic state of `SeaIceModel` so that shared
physical parameters live at the model level rather than being duplicated
inside each `SlabThermodynamics`. Along the way, corrects a sign error
in the Stefan correction and deletes the `sea_ice_model.jl` rebuild
hack.

**Key moves:**

- One `PhaseTransitions` on `SeaIceModel` (shared microscopic
  pure-ice ↔ water parameters), replacing one per slab.
- Two new top-level `SeaIceModel` fields, `ice_density` and
  `snow_density`, carrying the **bulk** porous-medium densities.
- `SlabThermodynamics` slimmed down to the state that is genuinely
  per-layer (surface T, heat BCs, internal-flux coefficient,
  concentration evolution).
- `latent_heat` rewritten as a per-mass function (with the correct
  sign); tendency kernels multiply externally by the appropriate bulk
  density.
- Removal of the `sea_ice_model.jl:174–204` rebuild hack that was
  forcing `ice_thermodynamics.top_heat_boundary_condition =
  PrescribedTemperature(0)` and assembling the combined snow+ice flux
  on the snow side at construction time.
- New documented extension point (`flux_kernel`) plus passthrough for
  pre-assembled `FluxFunction` as `internal_heat_flux`.

## Problem → solution

### P1. Duplicated liquid properties

`SlabThermodynamics` used to own a `PhaseTransitions`, which holds
`liquid_density`, `liquid_heat_capacity`, `reference_temperature`, and
`liquidus`. These describe the same liquid water regardless of whether
it emerges from melting snow or sea ice. Two copies made it
representationally possible for the two slabs to disagree.

**Fix.** A single `PhaseTransitions` lives on `SeaIceModel` as
`phase_transitions`. Both `ice_thermodynamics` and
`snow_thermodynamics` read from it.

### P2. Misplaced bulk density inside `PhaseTransitions` (#133)

Per @glwagner in #133: `PhaseTransitions.density` and
`PhaseTransitions.heat_capacity` refer to the microscopic pure-ice
crystal — the same substance in both the snow and sea-ice porous
media. `snow_slab_thermodynamics` used to override `density = 330` in
the snow's `PhaseTransitions`, which is a bulk snow density (porous
medium, including trapped air).

**Fix.** `PhaseTransitions` is now documented and used as a purely
microscopic descriptor. The two bulk densities live as top-level
`SeaIceModel` fields:

- `ice_density` (default 900 kg/m³, bulk sea ice including brine)
- `snow_density` (default 330 kg/m³, bulk snow including trapped air)

Both are wrapped as `Field{Center, Center, Nothing}` by the
constructor (scalars become `ConstantField`), matching the old
`model.ice_density` treatment.

### P3. Two roles for ρ in the latent-heat expression

The old `latent_heat(pt, T)` returned the volumetric form `ρ × ℒ(T)`,
with `ρ` sourced from `PhaseTransitions`. The `ρ` played two distinct
physical roles simultaneously:

1. **Mass-budget multiplier** — converts per-mass enthalpy to
   per-volume of the melting medium. Must be the **bulk** density.
2. **Stefan-correction factor** inside
   `ρℒ(T) = ρℒ₀ + (ρ_ℓ c_ℓ − ρ c)(T − T₀)`. Must be the
   **microscopic** pure-ice density.

A single `ρ` can play both correctly only when ρ_bulk = ρ_pure.
When the snow helper overrode `density = 330`, the `ρ × c` term
became physically incorrect.

**Fix.** `latent_heat(pt, T)` returns a **per-mass** Stefan-corrected
value using only microscopic properties:

```math
ℒ(T) = ℒ₀ + (ρ_ℓ c_ℓ / ρ − c)(T − T₀)
```

Call sites multiply externally by `ρ_ice_bulk` or `ρ_snow_bulk`.
Matches CICE and CLM/Noah-MP conventions. (A sign error that appeared
during an earlier iteration of the refactor was detected by the energy
conservation tests — now closes to `< 1e-15` across all combinations.)

### P4. Rebuild hack when both layers are present

The pre-refactor `SeaIceModel` constructor rebuilt both thermodynamics
when snow was supplied:

- `ice_thermodynamics` got `PrescribedTemperature(0)` as its top BC so
  its surface solve would be skipped.
- `snow_thermodynamics` got a combined `IceSnowConductiveFlux(ks, ki)`
  as its internal flux.

This coupled the two slabs at construction time and made the ice's
BC depend on whether snow existed elsewhere on the model.

**Fix.** The combined flux is constructed *inside* the layered
kernel from the two conductivities. The ice's melt/freeze tendency is
factored into a pure helper `ice_melt_freeze_tendency(…, Tui, …)` that
takes the ice-top temperature as an argument and performs no surface
solve. The layered kernel solves for `T_us`, computes `T_si`
analytically from the resistance ratio, and calls the helper with
`T_si` directly. No BC rewriting.

### P5. Liquidus plumbing

The `liquidus` is only ever used via `bottom_temperature(bc, liquidus)`
for `IceWaterThermalEquilibrium`. An interim design stored `liquidus`
inside each slab's `internal_heat_flux.parameters`, forcing the
`SeaIceModel` constructor to rebind it from
`model.phase_transitions.liquidus` into every slab.

**Fix.** `SlabThermodynamics` stores only the raw flux coefficient
(e.g. `ConductiveFlux`). The `FluxFunction` wrapper is assembled
inside the tendency kernel, pulling `liquidus` from
`model.phase_transitions` at call time. No per-slab liquidus state.

## Breaking changes to the UI

### `SlabThermodynamics` and its helpers

`PhaseTransitions` is no longer stored inside `SlabThermodynamics`.
Construct it once on the model:

```julia
# OLD
ice_thermodynamics = SlabThermodynamics(grid;
    phase_transitions = PhaseTransitions(; liquid_density = 1020))

# NEW
model = SeaIceModel(grid;
    ice_thermodynamics = SlabThermodynamics(grid),
    phase_transitions = PhaseTransitions(; liquid_density = 1020))
```

`snow_slab_thermodynamics` no longer accepts `density`,
`heat_capacity`, or `reference_latent_heat`:

```julia
# OLD
snow_thermodynamics = snow_slab_thermodynamics(grid;
    density = 330,
    heat_capacity = 2090,
    reference_latent_heat = 334e3)

# NEW
model = SeaIceModel(grid;
    snow_thermodynamics = snow_slab_thermodynamics(grid),  # just conductivity
    snow_density = 330,
    phase_transitions = PhaseTransitions(; reference_latent_heat = 334e3))
```

`SlabThermodynamics.internal_heat_flux` now stores the raw flux
coefficient rather than a pre-wrapped `FluxFunction`:

```julia
# OLD (introspection)
model.ice_thermodynamics.internal_heat_flux.parameters.flux.conductivity

# NEW
model.ice_thermodynamics.internal_heat_flux.conductivity
```

### `SeaIceModel`

New keyword arguments with safe defaults:

```julia
SeaIceModel(grid;
    phase_transitions = PhaseTransitions(eltype(grid)),  # NEW
    ice_density       = 900,                              # kg/m³, existed
    snow_density      = 330,                              # NEW
    ice_thermodynamics  = sea_ice_slab_thermodynamics(grid),
    snow_thermodynamics = nothing,
    ...)
```

### `latent_heat`

Now returns per-mass enthalpy. If you were using it for diagnostics,
multiply by the bulk density of the medium:

```julia
# OLD
enthalpy_density = latent_heat(phase_transitions, T)   # J/m³

# NEW
enthalpy_density = model.ice_density[i,j,1] * latent_heat(phase_transitions, T)
```

## The new UI in action

**Bare sea ice (default):**

```julia
using ClimaSeaIce, Oceananigans

grid = RectilinearGrid(size=(), topology=(Flat, Flat, Flat))
model = SeaIceModel(grid)                # uses defaults everywhere
set!(model, h=1, ℵ=1)
time_step!(model, 3600)
```

**Layered snow + ice:**

```julia
model = SeaIceModel(grid;
    ice_thermodynamics  = sea_ice_slab_thermodynamics(grid),
    snow_thermodynamics = snow_slab_thermodynamics(grid),
    ice_density         = 900,
    snow_density        = 330,
    snowfall            = 6e-5) # kg m⁻² s⁻¹
set!(model, h=1, ℵ=1, hs=0.1)
time_step!(model, 3600)
```

**Dynamics-only (no phase physics):**

```julia
dynamics = SeaIceMomentumEquation(grid; rheology = ViscousRheology(ν=1000))
model = SeaIceModel(grid;
    dynamics,
    ice_thermodynamics = nothing,
    ice_density        = 900,   # still required by momentum equations
    advection          = WENO())
```

**Custom liquidus / phase transition parameters:**

```julia
model = SeaIceModel(grid;
    phase_transitions = PhaseTransitions(;
        liquidus        = LinearLiquidus(; slope = 0.0543),
        reference_latent_heat = 335e3))
```

**Pluggable internal flux.** Four shapes accepted, documented in
`docs/src/physics/thermodynamics.md`:

```julia
# 1. Default ConductiveFlux
SlabThermodynamics(grid; internal_heat_flux = ConductiveFlux(conductivity=2))

# 2. Bare Function (signature (i,j,grid,Tu,clock,fields,parameters)->Q)
my_flux(i,j,grid,Tu,clock,fields,p) = ...
SlabThermodynamics(grid; internal_heat_flux = my_flux)

# 3. Pre-assembled FluxFunction (passthrough, no parameter injection)
SlabThermodynamics(grid; internal_heat_flux = FluxFunction(my_flux; parameters=(...,), ...))

# 4. Custom struct via flux_kernel extension (one-line pirate)
struct NonLinearConductiveFlux{T}; k0::T; α::T; end
ClimaSeaIce.SeaIceThermodynamics.flux_kernel(::NonLinearConductiveFlux) = my_nonlinear_kernel
SlabThermodynamics(grid; internal_heat_flux = NonLinearConductiveFlux(2.0, 0.01))
```

## Pros and cons

**Pros**

- *Correctness.* Single shared `PhaseTransitions` makes it structurally
  impossible for snow and ice to disagree about the liquid; the old
  duplication had no guardrail.
- *Physical transparency.* The volumetric `ρ × ℒ(T)` split into
  per-mass `ℒ(T)` × bulk density disentangles the two roles of ρ. The
  previously-hidden sign behaviour of the Stefan correction is now
  covered by machine-precision energy-conservation tests.
- *Pluggability.* Swapping in a non-default snow model (or ice
  thermodynamics) is simpler because the two slabs are no longer
  welded together by the constructor hack. Custom internal fluxes are
  supported via four documented paths.
- *Smaller constructor.* Removing the rebuild hack deletes ~30 lines
  of state surgery from `sea_ice_model.jl`.
- *Defaults are safe.* Existing scripts that only touched
  `ice_thermodynamics` and `snow_thermodynamics` keyword args continue
  to work, because the new `phase_transitions` and `snow_density`
  default sensibly.

**Cons**

- *Breaking change.* Any user code setting `density`, `heat_capacity`,
  or `reference_latent_heat` on `snow_slab_thermodynamics`, or reading
  `phase_transitions` off a `SlabThermodynamics`, or indexing into
  `.internal_heat_flux.parameters.flux`, needs to be updated. Users of
  default construction are unaffected.
- *Slightly larger kwarg surface on `SeaIceModel`.* Two new kwargs
  (`phase_transitions`, `snow_density`) add API surface. Both have
  safe defaults.
- *Layered kernel still assumes conductivity-based coupling.* The
  layered snow+ice kernel hardcodes `IceSnowConductiveFlux(ks, ki)`
  built from each layer's `.conductivity`. A user who wants a
  non-conductive layered coupling still has to touch the layered
  kernel. A future PR can lift this via a
  `combined_internal_flux(ice, snow)` trait.
- *`SlabThermodynamics.internal_heat_flux` type is looser.* It now
  holds a raw flux coefficient and the tendency kernel wraps it
  inline. Users who relied on the pre-wrapped `FluxFunction` shape
  for introspection need to adapt.

## Test plan

- [x] `test_snow_thermodynamics.jl` — 20/20 (layered physics,
      flooding, accumulation, melt ordering).
- [x] `test_energy_conservation.jl` — 6/6 at machine precision
      (`< 1e-15`) across bare/snow/freeze/melt/precipitation.
- [x] `test_sea_ice_advection.jl` — 10/10 (bare, layered,
      dynamics-only).
- [x] `test_checkpointing.jl` — 155/155 (all pickup modes; bare,
      ice+dynamics, snow+dynamics).
- [x] Time-stepping smoke (3 thermo paths × 2 steppers) — 5/5. Full
      144-combo matrix in `test_time_stepping.jl` skipped locally for
      CI time; will be exercised on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)