### PR TITLE
Improve summary for SeaIceModel

### DIFF
--- a/src/sea_ice_model.jl
+++ b/src/sea_ice_model.jl
@@ -221,10 +221,17 @@ end
 
 set!(model::SIM, new_clock::Clock) = set!(model.clock, new_clock)
 
-Base.summary(model::SIM) = "SeaIceModel"
 prettytime(model::SIM) = prettytime(model.clock.time)
 iteration(model::SIM) = model.clock.iteration
 architecture(model::SIM) = model.architecture
+
+function Base.summary(model::SIM)
+    A = Base.summary(architecture(model.grid))
+    G = nameof(typeof(model.grid))
+    return string("SeaIceModel{$A, $G}",
+                  "(time = ", prettytime(model.clock.time),
+                  ", iteration = ", prettysummary(model.clock.iteration), ")")
+end
 
 function Base.show(io::IO, model::SIM)
     grid = model.grid

--- a/src/sea_ice_model.jl
+++ b/src/sea_ice_model.jl
@@ -1,11 +1,12 @@
 using Oceananigans: tupleit, tracernames
-using Oceananigans.Architectures: architecture
 using Oceananigans.Advection: materialize_advection
+using Oceananigans.Architectures: architecture
 using Oceananigans.BoundaryConditions: regularize_field_boundary_conditions
 using Oceananigans.Fields: TracerFields, ConstantField
 using Oceananigans.Forcings: model_forcing
 using Oceananigans.OutputReaders: FieldTimeSeries
 using Oceananigans.TimeSteppers: TimeStepper
+using Oceananigans.Utils: prettysummary
 
 using ClimaSeaIce.SeaIceDynamics: materialize_solver, maybe_extended_grid
 using ClimaSeaIce.SeaIceThermodynamics: PrescribedTemperature, FluxFunction, IceSnowConductiveFlux,


### PR DESCRIPTION
Enhance summary method for SeaIceModel with grid info

Before this PR:

```julia
julia> coupled_model
EarthSystemModel{CPU}(time = 0 seconds, iteration = 0)
├── radiation: Nothing
├── atmosphere: Nothing
├── land: Nothing
├── sea_ice: SeaIceModel
├── ocean: HydrostaticFreeSurfaceModel{CPU, LatitudeLongitudeGrid}(time = 0 seconds, iteration = 0)
└── interfaces: ComponentInterfaces
```

After this PR:

```julia
julia> coupled_model
EarthSystemModel{CPU}(time = 0 seconds, iteration = 0)
├── radiation: Nothing
├── atmosphere: Nothing
├── land: Nothing
├── sea_ice: SeaIceModel{CPU, LatitudeLongitudeGrid}(time = 0 seconds, iteration = 0)
├── ocean: HydrostaticFreeSurfaceModel{CPU, LatitudeLongitudeGrid}(time = 0 seconds, iteration = 0)
└── interfaces: ComponentInterfaces
```
