### PR TITLE
Reconcile external stresses after restore

### DIFF
--- a/src/SeaIceDynamics/sea_ice_momentum_equations.jl
+++ b/src/SeaIceDynamics/sea_ice_momentum_equations.jl
@@ -99,23 +99,7 @@ materialize_solver(mom, velocity_grid) = mom
 end
 
 reconcile_dynamics!(model, ::Nothing) = nothing
-
-function reconcile_dynamics!(model, mom::SeaIceMomentumEquation)
-    grid = model.velocities.u.grid
-    arch = architecture(grid)
-
-    fields = merge(mom.auxiliaries.fields, model.velocities,
-                   (; h = model.ice_thickness,
-                      ℵ = model.ice_concentration,
-                      ρ = model.sea_ice_density))
-
-    launch!(arch, grid, mom.solver.kernel_parameters, _reconcile_external_stress_coefficients!,
-            grid, model.clock, fields,
-            mom.external_momentum_stresses.top,
-            mom.external_momentum_stresses.bottom)
-
-    return nothing
-end
+reconcile_dynamics!(model, mom::SeaIceMomentumEquation) = nothing
 
 function Base.show(io::IO, sime::SeaIceMomentumEquation)
 

--- a/src/SeaIceDynamics/sea_ice_momentum_equations.jl
+++ b/src/SeaIceDynamics/sea_ice_momentum_equations.jl
@@ -1,7 +1,9 @@
 using ClimaSeaIce.Rheologies
 using Adapt
-
-import Oceananigans: prognostic_state, restore_prognostic_state!
+using KernelAbstractions: @kernel, @index
+using Oceananigans: restore_prognostic_state!, prognostic_state
+using Oceananigans.Architectures: architecture
+using Oceananigans.Utils: launch!
 
 struct SeaIceMomentumEquation{S, C, R, F, A, ES, FT}
     coriolis :: C
@@ -88,6 +90,33 @@ prognostic_fields(model, mom::SeaIceMomentumEquation) = merge(model.velocities, 
 maybe_extended_grid(mom, grid) = grid
 materialize_solver(mom, velocity_grid) = mom
 
+@kernel function _reconcile_external_stress_coefficients!(grid, clock, fields, top_stress, bottom_stress)
+    i, j = @index(Global, NTuple)
+    kᴺ = size(grid, 3)
+
+    compute_implicit_stress_coefficients!(i, j, kᴺ, grid, top_stress, clock, fields)
+    compute_implicit_stress_coefficients!(i, j, kᴺ, grid, bottom_stress, clock, fields)
+end
+
+reconcile_dynamics!(model, ::Nothing) = nothing
+
+function reconcile_dynamics!(model, mom::SeaIceMomentumEquation)
+    grid = model.velocities.u.grid
+    arch = architecture(grid)
+
+    fields = merge(mom.auxiliaries.fields, model.velocities,
+                   (; h = model.ice_thickness,
+                      ℵ = model.ice_concentration,
+                      ρ = model.sea_ice_density))
+
+    launch!(arch, grid, mom.solver.kernel_parameters, _reconcile_external_stress_coefficients!,
+            grid, model.clock, fields,
+            mom.external_momentum_stresses.top,
+            mom.external_momentum_stresses.bottom)
+
+    return nothing
+end
+
 function Base.show(io::IO, sime::SeaIceMomentumEquation)
 
     aux_fields = keys(sime.auxiliaries.fields)
@@ -107,11 +136,11 @@ end
 ##### Checkpointing
 #####
 
-function prognostic_state(mom::SeaIceMomentumEquation)
+function Oceananigans.prognostic_state(mom::SeaIceMomentumEquation)
     return (; fields = prognostic_state(fields(mom)))
 end
 
-function restore_prognostic_state!(mom::SeaIceMomentumEquation, state)
+function Oceananigans.restore_prognostic_state!(mom::SeaIceMomentumEquation, state)
     restore_prognostic_state!(fields(mom), state.fields)
     return mom
 end

--- a/src/SeaIceDynamics/split_explicit_momentum_equations.jl
+++ b/src/SeaIceDynamics/split_explicit_momentum_equations.jl
@@ -80,6 +80,23 @@ function materialize_solver(mom::SplitExplicitMomentumEquation, grid)
                                   mom.minimum_mass)
 end
 
+function reconcile_dynamics!(model, mom::SplitExplicitMomentumEquation)
+    grid = model.velocities.u.grid
+    arch = architecture(grid)
+
+    fields = merge(mom.auxiliaries.fields, model.velocities,
+                   (; h = model.ice_thickness,
+                      ℵ = model.ice_concentration,
+                      ρ = model.sea_ice_density))
+
+    launch!(arch, grid, mom.solver.kernel_parameters, _reconcile_external_stress_coefficients!,
+            grid, model.clock, fields,
+            mom.external_momentum_stresses.top,
+            mom.external_momentum_stresses.bottom)
+
+    return nothing
+end
+
 # Reset the velocities to the previous time step
 # This does nothing for a FE model, but is necessary for an RK model.
 reset_velocities!(u, v, timestepper) = nothing

--- a/src/sea_ice_model.jl
+++ b/src/sea_ice_model.jl
@@ -8,7 +8,7 @@ using Oceananigans.OutputReaders: FieldTimeSeries
 using Oceananigans.TimeSteppers: TimeStepper
 using Oceananigans.Utils: prettysummary
 
-using ClimaSeaIce.SeaIceDynamics: materialize_solver, maybe_extended_grid
+using ClimaSeaIce.SeaIceDynamics: materialize_solver, maybe_extended_grid, reconcile_dynamics!
 using ClimaSeaIce.SeaIceThermodynamics: PrescribedTemperature, FluxFunction, IceSnowConductiveFlux,
                                         PhaseTransitions, internal_flux_function
 using ClimaSeaIce.SeaIceThermodynamics.HeatBoundaryConditions: flux_summary
@@ -16,6 +16,7 @@ using ClimaSeaIce.SeaIceThermodynamics.HeatBoundaryConditions: flux_summary
 import Oceananigans.Architectures: architecture
 import Oceananigans.Models: update_model_field_time_series!
 import Oceananigans.OutputWriters: default_included_properties
+import Oceananigans.TimeSteppers: update_state!, reconcile_state!
 
 @inline instantiate(T::DataType) = T()
 @inline instantiate(T) = T
@@ -341,7 +342,14 @@ function restore_prognostic_state!(model::SeaIceModel, state)
     restore_prognostic_state!(model.ice_thermodynamics, state.ice_thermodynamics)
     restore_prognostic_state!(model.snow_thermodynamics, state.snow_thermodynamics)
     restore_prognostic_state!(model.dynamics, state.dynamics)
+    update_state!(model)
+    reconcile_state!(model)
     return model
 end
 
 restore_prognostic_state!(::SeaIceModel, ::Nothing) = nothing
+
+function reconcile_state!(model::SeaIceModel)
+    reconcile_dynamics!(model, model.dynamics)
+    return nothing
+end

--- a/test/test_checkpointing.jl
+++ b/test/test_checkpointing.jl
@@ -3,7 +3,7 @@ using ClimaSeaIce.SeaIceDynamics
 using ClimaSeaIce.SeaIceThermodynamics
 using Test
 
-using Oceananigans.Fields: @allowscalar
+using Oceananigans.Fields: @allowscalar, Field, interior
 using Oceananigans: prognostic_fields
 
 # Same test as in Oceananigans
@@ -179,4 +179,65 @@ end
     end
 
     run_checkpointer_tests(true_model, test_model, Δt)
+end
+
+function test_external_stress_coefficient_reconciliation(arch)
+    Nx, Ny = 16, 16
+    Lx, Ly = 100, 100
+    Δt = 1
+
+    grid = RectilinearGrid(arch, size=(Nx, Ny), x=(0, Lx), y=(0, Ly), topology=(Bounded, Bounded, Flat))
+
+    uₐ = Field{Face, Center, Nothing}(grid)
+    vₐ = Field{Center, Face, Nothing}(grid)
+    uₒ = Field{Face, Center, Nothing}(grid)
+    vₒ = Field{Center, Face, Nothing}(grid)
+
+    set!(uₐ, 0.25)
+    set!(vₐ, -0.15)
+    set!(uₒ, -0.05)
+    set!(vₒ, 0.1)
+
+    τₐ = SemiImplicitStress(uₑ = uₐ, vₑ = vₐ, Cᴰ = 1e-3, ρₑ = 1.2)
+    τₒ = SemiImplicitStress(uₑ = uₒ, vₑ = vₒ, Cᴰ = 5e-3, ρₑ = 1026.0)
+
+    dynamics = SeaIceMomentumEquation(grid; top_momentum_stress = τₐ,
+                                            bottom_momentum_stress = τₒ)
+
+    true_model = SeaIceModel(grid; dynamics)
+    set!(true_model; h = 1.0, ℵ = 0.8, u = 0.12, v = -0.07)
+
+    true_simulation = Simulation(true_model, Δt = Δt, stop_iteration = 5)
+    true_simulation.output_writers[:checkpointer] =
+        Checkpointer(true_model, schedule = IterationInterval(5), overwrite_existing = true)
+
+    run!(true_simulation)
+
+    checkpointed_model = deepcopy(true_simulation.model)
+
+    restored_model = deepcopy(true_model)
+    restored_simulation = Simulation(restored_model, Δt = Δt, stop_iteration = 5)
+    restored_simulation.output_writers[:checkpointer] =
+        Checkpointer(restored_model, schedule = IterationInterval(5), overwrite_existing = true)
+
+    set!(restored_simulation, checkpoint = "checkpoint_iteration5.jld2")
+
+    restored_bottom = restored_simulation.model.dynamics.external_momentum_stresses.bottom
+    checkpointed_bottom = checkpointed_model.dynamics.external_momentum_stresses.bottom
+    restored_top = restored_simulation.model.dynamics.external_momentum_stresses.top
+    checkpointed_top = checkpointed_model.dynamics.external_momentum_stresses.top
+
+    @test Array(interior(restored_bottom.τᵢᵤ)) ≈ Array(interior(checkpointed_bottom.τᵢᵤ)) rtol = 1e-3
+    @test Array(interior(restored_bottom.τᵢᵥ)) ≈ Array(interior(checkpointed_bottom.τᵢᵥ)) rtol = 1e-3
+    @test Array(interior(restored_top.τᵢᵤ)) ≈ Array(interior(checkpointed_top.τᵢᵤ)) rtol = 1e-3
+    @test Array(interior(restored_top.τᵢᵥ)) ≈ Array(interior(checkpointed_top.τᵢᵥ)) rtol = 1e-3
+
+    rm("checkpoint_iteration5.jld2", force = true)
+    rm("checkpoint_iteration0.jld2", force = true)
+
+    return nothing
+end
+
+@testset "Checkpointing reconciles semi-implicit external stresses" begin
+    test_external_stress_coefficient_reconciliation(CPU())
 end


### PR DESCRIPTION
## Summary

This PR fixes checkpoint pickup for `SeaIceModel` when semi-implicit external momentum stresses are in use.

## Root cause

`ClimaSeaIce` stores semi-implicit drag coefficients inside the external stress objects and uses them when reconstructing the total external stress. The prognostic state was restoring correctly from checkpoint, but these derived stress coefficients were not being reconciled after restore.

As a result, a restarted run could begin from the correct `u`, `v`, `h`, `ℵ`, tracer, and timestepper state, but still reconstruct inconsistent external stresses until the next momentum update recomputed the coefficients. This showed up downstream as a checkpoint/restart reproducibility failure in coupled NumericalEarth runs.

## What this PR changes

- adds a reconcile step for `SeaIceMomentumEquation` that recomputes implicit coefficients for the top and bottom external momentum stresses from the restored sea-ice state,
- calls `update_state!(model)` and `reconcile_state!(model)` at the end of `restore_prognostic_state!(model::SeaIceModel, state)`,
- keeps the reconcile hook as a no-op when `dynamics === nothing`.

## Why this is needed

Restoring field values alone is not sufficient for semi-implicit stresses, because the drag coefficient state depends on restored velocities, thickness, concentration, and external velocities. That derived state must also be rebuilt during checkpoint pickup to make restart behavior self-consistent.

## Scope

This is intentionally narrow. It does not change the continuous time-stepping path; it only reconciles derived semi-implicit external stress state after restore.

## Validation

I validated this against the downstream NumericalEarth checkpoint reproduction that was failing after `ClimaSeaIce v0.5.1`:

- `julia --project=. checkpointer_investigations.jl`
- `julia --project=. --color=no -e 'include("test/test_checkpointer.jl")'`

Before this fix, restarted coupled runs diverged in resumed ocean and sea-ice velocities. With this restore-time reconciliation in place, the restored sea-ice state is internally consistent again.