### PR TITLE
(0.5.5) Save SemiImplicitStress caches across checkpoint

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaSeaIce"
 uuid = "6ba0ff68-24e6-4315-936c-2e99227c95a4"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.5.4"
+version = "0.5.5"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/SeaIceDynamics/sea_ice_momentum_equations.jl
+++ b/src/SeaIceDynamics/sea_ice_momentum_equations.jl
@@ -107,11 +107,43 @@ end
 ##### Checkpointing
 #####
 
+# `external_momentum_stresses` is a `NamedTuple` of `(top, bottom)`. Most
+# stress types are stateless (a `NamedTuple` of externally-supplied flux fields,
+# `NoFreeDrift`, `Nothing`), but `SemiImplicitStress` caches per-cell implicit
+# coefficients in its `τᵢᵤ`/`τᵢᵥ` Fields. Those caches are written by
+# `compute_implicit_stress_coefficients!` during the EVP substep loop and read
+# by `_compute_sea_ice_ocean_stress!` (via `implicit_τx_coefficient`) every
+# time the coupled `update_state!` runs — including the call triggered by
+# `initialize_simulation!` on a restored simulation. They must round-trip
+# through the checkpoint, otherwise the first post-restore flux computation
+# reads zeros, the sea-ice → ocean stress is recomputed wrong, and the ocean
+# trajectory drifts ~1e-9 per step.
+
+@inline stress_state(s) = nothing
+@inline stress_state(s::SemiImplicitStress) =
+    (τᵢᵤ = prognostic_state(s.τᵢᵤ), τᵢᵥ = prognostic_state(s.τᵢᵥ))
+
+@inline restore_stress!(s, ::Nothing) = nothing
+@inline restore_stress!(s, _) = nothing
+function restore_stress!(s::SemiImplicitStress, state)
+    restore_prognostic_state!(s.τᵢᵤ, state.τᵢᵤ)
+    restore_prognostic_state!(s.τᵢᵥ, state.τᵢᵥ)
+    return nothing
+end
+
 function prognostic_state(mom::SeaIceMomentumEquation)
-    return (; fields = prognostic_state(fields(mom)))
+    return (; fields = prognostic_state(fields(mom)),
+              external_momentum_stresses = (top    = stress_state(mom.external_momentum_stresses.top),
+                                            bottom = stress_state(mom.external_momentum_stresses.bottom)))
 end
 
 function restore_prognostic_state!(mom::SeaIceMomentumEquation, state)
     restore_prognostic_state!(fields(mom), state.fields)
+    # Backwards-compatible: older checkpoints predate this fix and omit the
+    # `external_momentum_stresses` entry.
+    if hasproperty(state, :external_momentum_stresses)
+        restore_stress!(mom.external_momentum_stresses.top,    state.external_momentum_stresses.top)
+        restore_stress!(mom.external_momentum_stresses.bottom, state.external_momentum_stresses.bottom)
+    end
     return mom
 end

--- a/test/test_checkpointing.jl
+++ b/test/test_checkpointing.jl
@@ -3,7 +3,7 @@ using ClimaSeaIce.SeaIceDynamics
 using ClimaSeaIce.SeaIceThermodynamics
 using Test
 
-using Oceananigans.Fields: @allowscalar
+using Oceananigans.Fields: @allowscalar, ConstantField
 using Oceananigans: prognostic_fields
 
 # Same test as in Oceananigans
@@ -179,4 +179,97 @@ end
     end
 
     run_checkpointer_tests(true_model, test_model, Δt)
+end
+
+@testset "Checkpointing SemiImplicitStress caches" begin
+    # Regression test: `SemiImplicitStress` (used for ice-ocean and
+    # ice-atmosphere drag) caches per-cell implicit-stress coefficients in
+    # `τᵢᵤ`/`τᵢᵥ` Fields. They are written by `compute_implicit_stress_coefficients!`
+    # inside the EVP substep loop and read by `_compute_sea_ice_ocean_stress!`
+    # (via `implicit_τx_coefficient`) every time the coupled `update_state!`
+    # runs — including the call triggered by `initialize_simulation!` on a
+    # restored simulation. If `prognostic_state(::SeaIceMomentumEquation)`
+    # doesn't walk `external_momentum_stresses`, these caches do not
+    # round-trip and the first post-restore flux computation reads zeros,
+    # producing ocean-velocity drift in a coupled simulation.
+
+    Δt = 1
+    grid = RectilinearGrid(CPU(), size=(16, 16), x=(0, 100), y=(0, 100),
+                           topology=(Bounded, Bounded, Flat))
+
+    # SeaIceModel with `SemiImplicitStress` on both ice surfaces — exercises
+    # both top and bottom branches of `external_momentum_stresses`.
+    function make_model(grid)
+        top    = SemiImplicitStress(; uₑ=ConstantField(10), vₑ=ConstantField(5),
+                                      ρₑ=1.225,  Cᴰ=1.5e-3)
+        bottom = SemiImplicitStress(; uₑ=ConstantField(0),  vₑ=ConstantField(0),
+                                      ρₑ=1026.0, Cᴰ=5.5e-3)
+        dynamics = SeaIceMomentumEquation(grid; top_momentum_stress    = top,
+                                                bottom_momentum_stress = bottom)
+        SeaIceModel(grid; dynamics, ice_thermodynamics=SlabThermodynamics(grid))
+    end
+
+    function set_random_initial_conditions!(model)
+        for field in merge(model.velocities,
+                           (h = model.ice_thickness, ℵ = model.ice_concentration))
+            set!(field, (x, y) -> rand() * 1e-5)
+        end
+    end
+
+    # Per-cache snapshot helper for the τᵢᵤ/τᵢᵥ Fields.
+    cache(model, side, name) =
+        Array(parent(getproperty(getproperty(model.dynamics.external_momentum_stresses, side), name)))
+
+    # Outer round-trip via the existing helper — `prognostic_fields` equality,
+    # for `SeaIceMomentumEquation`-with-`SemiImplicitStress` configurations.
+    true_model = make_model(grid)
+    test_model = deepcopy(true_model)
+    set_random_initial_conditions!(true_model)
+    run_checkpointer_tests(true_model, test_model, Δt)
+
+    # Focused cache round-trip. `test_model_equality` only covers
+    # `prognostic_fields(::SeaIceModel)`, which does not include
+    # `external_momentum_stresses` — so the τᵢᵤ/τᵢᵥ round-trip must be checked
+    # directly here.
+    @testset "τᵢᵤ/τᵢᵥ cache round-trip" begin
+        prefix = "semi_implicit_stress_checkpoint"
+
+        # Save: run the EVP loop long enough to populate the caches.
+        saved = make_model(grid)
+        set_random_initial_conditions!(saved)
+        sim_save = Simulation(saved; Δt, stop_iteration=5)
+        sim_save.output_writers[:checkpointer] =
+            Checkpointer(saved; schedule=IterationInterval(5),
+                                overwrite_existing=true, prefix)
+        run!(sim_save)
+
+        saved_caches = (top    = (τᵢᵤ = cache(saved, :top, :τᵢᵤ),
+                                  τᵢᵥ = cache(saved, :top, :τᵢᵥ)),
+                        bottom = (τᵢᵤ = cache(saved, :bottom, :τᵢᵤ),
+                                  τᵢᵥ = cache(saved, :bottom, :τᵢᵥ)))
+
+        # Sanity: the substep loop actually populated the caches — otherwise
+        # the round-trip is vacuously satisfied by both sides being zero.
+        @test maximum(abs.(saved_caches.top.τᵢᵤ))    > 0
+        @test maximum(abs.(saved_caches.bottom.τᵢᵤ)) > 0
+
+        # Restore: fresh model, pull state from disk.
+        restored = make_model(grid)
+        sim_restore = Simulation(restored; Δt, stop_iteration=5)
+        sim_restore.output_writers[:checkpointer] =
+            Checkpointer(restored; schedule=IterationInterval(5),
+                                   overwrite_existing=true, prefix)
+        set!(sim_restore, checkpoint="$(prefix)_iteration5.jld2")
+
+        # Round-trip equality must be bit-exact: every τᵢᵤ/τᵢᵥ Field is a
+        # deterministic function of the saved prognostic state.
+        @test cache(restored, :top,    :τᵢᵤ) == saved_caches.top.τᵢᵤ
+        @test cache(restored, :top,    :τᵢᵥ) == saved_caches.top.τᵢᵥ
+        @test cache(restored, :bottom, :τᵢᵤ) == saved_caches.bottom.τᵢᵤ
+        @test cache(restored, :bottom, :τᵢᵥ) == saved_caches.bottom.τᵢᵥ
+
+        for f in filter(p -> startswith(p, prefix), readdir())
+            rm(f; force=true)
+        end
+    end
 end


### PR DESCRIPTION
## Summary

`SemiImplicitStress` (used for ice-ocean and ice-atmosphere drag) caches per-cell implicit-stress coefficients in its `τᵢᵤ`/`τᵢᵥ` Fields. They are written by `compute_implicit_stress_coefficients!` inside the EVP substep loop and read by `_compute_sea_ice_ocean_stress!` (via `implicit_τx_coefficient`) **every time** the coupled `update_state!` runs — including the call triggered by `initialize_simulation!` on a restored simulation.

`prognostic_state(::SeaIceMomentumEquation)` previously only walked `auxiliaries.fields` and skipped `external_momentum_stresses`, so those caches did not round-trip. In a coupled ocean-sea-ice simulation this manifests as a ~1e-9 per-step drift in ocean velocities after a checkpoint restore (the first post-restore `update_state!` reads zero caches, computes a wrong sea-ice → ocean stress, and writes a wrong ocean surface BC). It was caught by failures in NumericalEarth.jl's `test/test_checkpointer.jl` (https://github.com/NumericalEarth/NumericalEarth.jl/pull/220).

## Structure

This PR is split into two commits:

1. **Add failing test** (`test/test_checkpointing.jl`) — a focused `Checkpointing SemiImplicitStress caches` testset that builds a `SeaIceModel` with `SemiImplicitStress` top + bottom drag, runs the EVP loop, checkpoints, restores into a fresh model, and asserts the τᵢᵤ/τᵢᵥ caches round-trip bit-exact. On `main` this fails 4/6 assertions (caches are zero post-restore, non-zero pre-checkpoint).

2. **Fix** (`src/SeaIceDynamics/sea_ice_momentum_equations.jl` + version bump 0.5.4 → 0.5.5) — extend `prognostic_state(::SeaIceMomentumEquation)` to also serialize the `τᵢᵤ`/`τᵢᵥ` caches on each `external_momentum_stresses` entry, with a `hasproperty` guard in `restore_prognostic_state!` for backwards-compatibility with checkpoint files written before this PR.

## Test plan

- [x] `TEST_GROUP=checkpointing julia --project=test test/runtests.jl` — passes all 198 checkpoint assertions with the fix (124 existing + 31 snow + 43 new SemiImplicitStress)
- [x] Verified the test fails on `main` (4/6 assertions in the new testset)
- [x] Verified the fix makes NumericalEarth.jl's `test/test_checkpointer.jl` go from 29/34 → 34/34 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)