### PR TITLE
[codex] Remove broad Oceananigans import in slab tendencies

### DIFF
--- a/src/SeaIceThermodynamics/slab_thermodynamics_tendencies.jl
+++ b/src/SeaIceThermodynamics/slab_thermodynamics_tendencies.jl
@@ -1,5 +1,4 @@
 using ClimaSeaIce.SeaIceThermodynamics.HeatBoundaryConditions: bottom_temperature, top_surface_temperature
-using Oceananigans
 
 #####
 ##### Ice interior conductive flux


### PR DESCRIPTION
## What changed
Removed the unused broad `using Oceananigans` from `src/SeaIceThermodynamics/slab_thermodynamics_tendencies.jl`.

## Why
This file does not use any `Oceananigans` names directly, so the broad import is unnecessary noise and works against the package's quality-assurance cleanup around explicit imports.

## Impact
No behavior change. This is a small import-scope cleanup that keeps the file aligned with the QA expectations.

## Validation
Ran the quality-assurance test suite from a fresh temporary environment that develops the current checkout:

`julia --startup-file=no -e 'using Pkg; tmp = mktempdir(); Pkg.activate(tmp); Pkg.develop(path=pwd()); withenv("TEST_GROUP" => "quality_assurance") do; Pkg.test("ClimaSeaIce") end'`
