### PR TITLE
[codex] Remove redundant forward Euler restore overload

### DIFF
--- a/src/forward_euler_timestepper.jl
+++ b/src/forward_euler_timestepper.jl
@@ -60,5 +60,4 @@ reset!(::ForwardEulerTimeStepper) = nothing
 
 # Forward Euler is a self-starting timestepper, so no state needs to be saved
 prognostic_state(::ForwardEulerTimeStepper) = nothing
-restore_prognostic_state!(ts::ForwardEulerTimeStepper, state) = ts
 restore_prognostic_state!(ts::ForwardEulerTimeStepper, ::Nothing) = ts


### PR DESCRIPTION
## What changed
Removed the redundant generic `restore_prognostic_state!` overload for `ForwardEulerTimeStepper` and kept the explicit `::Nothing` restore method.

## Why
`prognostic_state(::ForwardEulerTimeStepper)` returns `nothing`, so the generic restore overload was broader than necessary and made the `::Nothing` method redundant.

## Impact
No behavior change for valid checkpoint restores. The checkpointing contract is now tighter and clearer.

## Validation
Loaded the package from a fresh temporary environment that develops the current checkout:

`julia --startup-file=no -e 'using Pkg; tmp = mktempdir(); Pkg.activate(tmp); Pkg.develop(path=pwd()); using ClimaSeaIce'`
