### PR TITLE
[codex] Tighten stale comments

### DIFF
--- a/src/ClimaSeaIce.jl
+++ b/src/ClimaSeaIce.jl
@@ -41,7 +41,7 @@ export SeaIceModel,
    
 @inline ice_mass(i, j, k, grid, h, ℵ, ρ) = @inbounds h[i, j, k] * ρ[i, j, k] * ℵ[i, j, k]
 
-# TODO: move this to Oceananigans
+# Candidate for upstreaming to Oceananigans.
 include("forward_euler_timestepper.jl")
 
 include("SeaIceThermodynamics/SeaIceThermodynamics.jl")

--- a/src/SeaIceDynamics/sea_ice_external_stress.jl
+++ b/src/SeaIceDynamics/sea_ice_external_stress.jl
@@ -1,11 +1,13 @@
 using Adapt
 using Oceananigans.Fields: ZeroField
 
-# Fallback
+# Default no-op implicit stress coefficients for stress types without
+# an implicit component.
 @inline implicit_τx_coefficient(i, j, k, grid, stress, clock, fields) = zero(grid)
 @inline implicit_τy_coefficient(i, j, k, grid, stress, clock, fields) = zero(grid)
 
-# Fallback
+# Default no-op explicit stresses for stress types without
+# an explicit component.
 @inline explicit_τx(i, j, k, grid, stress, clock, fields) = zero(grid)
 @inline explicit_τy(i, j, k, grid, stress, clock, fields) = zero(grid)
 
@@ -15,7 +17,7 @@ using Oceananigans.Fields: ZeroField
 @inline explicit_τx(i, j, k, grid, stress::AbstractArray, clock, fields) =  @inbounds stress[i, j, k]
 @inline explicit_τy(i, j, k, grid, stress::AbstractArray, clock, fields) =  @inbounds stress[i, j, k]
 
-# NamedTuple stess (assuming it is `u` and `v`)
+# NamedTuple stress (assuming it is `u` and `v`)
 @inline implicit_τx_coefficient(i, j, k, grid, stress::NamedTuple, clock, fields) = implicit_τx_coefficient(i, j, k, grid, stress.u, clock, fields)
 @inline implicit_τy_coefficient(i, j, k, grid, stress::NamedTuple, clock, fields) = implicit_τy_coefficient(i, j, k, grid, stress.v, clock, fields)
 

--- a/src/SeaIceThermodynamics/SeaIceThermodynamics.jl
+++ b/src/SeaIceThermodynamics/SeaIceThermodynamics.jl
@@ -189,7 +189,7 @@ import Oceananigans.TimeSteppers: time_step!, update_state!
 
 import Oceananigans.Utils: prettytime
 
-# TODO: Fix this after this PR
+# Enthalpy thermodynamics is not included in this module yet.
 # include("EnthalpyMethodThermodynamics.jl")
 
 include("slab_heat_and_tracer_fluxes.jl")

--- a/src/forward_euler_timestepper.jl
+++ b/src/forward_euler_timestepper.jl
@@ -1,4 +1,4 @@
-#TODO: Move to Oceananigans??
+# Candidate for upstreaming to Oceananigans.
 using Oceananigans.TimeSteppers: AbstractTimeStepper
 using Oceananigans.Fields: FunctionField, location
 using Oceananigans.Utils: @apply_regionally, apply_regionally!


### PR DESCRIPTION
## What changed
Tightened a few stale or low-signal comments:

- replaced PR-specific TODO wording with stable descriptions
- clarified two no-op stress fallback comments
- fixed the `NamedTuple stess` typo

## Why
These comments were either outdated, overly vague, or tied to temporary PR context. This keeps the codebase easier to scan without changing behavior.

## Impact
No behavior change. Comment-only cleanup.

## Validation
Loaded the package from a fresh temporary environment that develops the current checkout:

`julia --startup-file=no -e 'using Pkg; tmp = mktempdir(); Pkg.activate(tmp); Pkg.develop(path=pwd()); using ClimaSeaIce'`
