### PR TITLE
[codex] Use docs sources for CI

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -21,7 +21,7 @@ jobs:
           version: '1.12'
           show-versioninfo: true
       - name: Install dependencies
-        run: julia --color=yes --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        run: julia --color=yes --project=docs/ -e 'using Pkg; Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,9 +1,13 @@
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+ClimaSeaIce = "6ba0ff68-24e6-4315-936c-2e99227c95a4"
 DataDeps = "124859b0-ceae-595e-8997-d05f6a7a8dfe"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
+
+[sources]
+ClimaSeaIce = {path = ".."}
 
 [compat]
 CairoMakie = "0.15"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -11,5 +11,5 @@ ClimaSeaIce = {path = ".."}
 
 [compat]
 CairoMakie = "0.15"
-Documenter = "1"
+Documenter = "1.11"
 Literate = "2.9"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -97,24 +97,7 @@ for file in files
     rm(file)
 end
 
-# Replace with below once https://github.com/JuliaDocs/Documenter.jl/pull/2692 is merged and available.
-#  deploydocs(repo = "github.com/CliMA/ClimaSeaIce.jl",
-#    deploy_repo = "github.com/CliMA/ClimaSeaIceDocumentation",
-#    devbranch = "main",
-#    push_preview = true)
-if get(ENV, "GITHUB_EVENT_NAME", "") == "pull_request"
-    deploydocs(repo = "github.com/CliMA/ClimaSeaIce.jl",
-               repo_previews = "github.com/CliMA/ClimaSeaIceDocumentation",
-               devbranch = "main",
-               forcepush = true,
-               push_preview = true,
-               versions = ["stable" => "v^", "v#.#.#", "dev" => "dev"])
-else
-    repo = "github.com/CliMA/ClimaSeaIceDocumentation"
-    withenv("GITHUB_REPOSITORY" => repo) do
-        deploydocs(repo = repo,
-                   devbranch = "main",
-                   forcepush = true,
-                   versions = ["stable" => "v^", "v#.#.#", "dev" => "dev"])
-    end
-end
+ deploydocs(repo = "github.com/CliMA/ClimaSeaIce.jl",
+            deploy_repo = "github.com/CliMA/ClimaSeaIceDocumentation",
+            devbranch = "main",
+            push_preview = true)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -97,7 +97,7 @@ for file in files
     rm(file)
 end
 
- deploydocs(repo = "github.com/CliMA/ClimaSeaIce.jl",
-            deploy_repo = "github.com/CliMA/ClimaSeaIceDocumentation",
-            devbranch = "main",
-            push_preview = true)
+deploydocs(repo = "github.com/CliMA/ClimaSeaIce.jl",
+           deploy_repo = "github.com/CliMA/ClimaSeaIceDocumentation",
+           devbranch = "main",
+           push_preview = true)


### PR DESCRIPTION
## Summary

Use the docs environment's `[sources]` configuration to resolve `ClimaSeaIce` from the repository root, and simplify the documentation workflow to instantiate the docs project directly.

## Changes

- add `ClimaSeaIce` to `docs/Project.toml`
- add `[sources]` with `ClimaSeaIce = { path = ".." }`
- remove `Pkg.develop(...)` from the documentation workflow
- keep the workflow install step as plain `Pkg.instantiate()`

## Why

This matches the `NumericalEarth.jl` docs setup and avoids mutating the docs environment in CI with a `Pkg.develop` step.

## Validation

- ran `julia --project=docs -e 'using Pkg; Pkg.instantiate()'`
- confirmed the docs environment resolves `ClimaSeaIce` through the `[sources]` entry
