### PR TITLE
[codex] Improve docs references and public docstrings

### DIFF
--- a/docs/climaseaice.bib
+++ b/docs/climaseaice.bib
@@ -61,7 +61,7 @@
 }
 
 @unpublished{SilvestriEtAl2026,
-  author = {Silvestri, Stefano and Campin, Jean-Michel and Wagner, Glenn L. and Constantinou, Navid C. and Lee, Xiaolong Kevin and Ferrari, Raffaele},
+  author = {Silvestri, Simone and Campin, Jean-Michel and Wagner, Gregory L. and Constantinou, Navid C. and Lee, Xin Kai and Ferrari, Raffaele},
   title = {A low-storage {Runge}-{Kutta} framework for nonlinear free-surface ocean models},
   year = {2026},
   note = {J. Adv. Model. Earth Sy., submitted in April 2026},

--- a/docs/climaseaice.bib
+++ b/docs/climaseaice.bib
@@ -59,3 +59,11 @@
   pages = {1550--1575},
   doi = {10.1029/JC076i006p01550}
 }
+
+@unpublished{SilvestriEtAl2026,
+  author = {Silvestri, Stefano and Campin, Jean-Michel and Wagner, Glenn L. and Constantinou, Navid C. and Lee, Xiaolong Kevin and Ferrari, Raffaele},
+  title = {A low-storage {Runge}-{Kutta} framework for nonlinear free-surface ocean models},
+  year = {2026},
+  note = {J. Adv. Model. Earth Sy., submitted in April 2026},
+  doi = {10.22541/essoar.15002225/v1}
+}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -76,6 +76,7 @@ makedocs(
       format = format,
        pages = pages,
      doctest = true,
+       draft = false,
     warnonly = [:cross_references],
        clean = true,
    checkdocs = :exports,

--- a/docs/src/timestepping.md
+++ b/docs/src/timestepping.md
@@ -50,8 +50,9 @@ Forward Euler is first-order accurate and may require smaller time steps for sta
 
 ## Split Runge-Kutta Timestepper (Default)
 
-The Split Runge-Kutta 3rd order (`SplitRungeKutta3`) scheme is a 3rd-order accurate method that
-performs three substeps per full time step. This is the default timestepper and
+The Split Runge-Kutta 3rd order (`SplitRungeKutta3`) scheme is a 3rd-order accurate
+low-storage method following the framework described by [Silvestri et al. 2026](@cite SilvestriEtAl2026).
+It performs three substeps per full time step. This is the default timestepper and
 is recommended for most applications.
 
 ```jldoctest timesteppers
@@ -71,9 +72,10 @@ SeaIceModel{CPU, RectilinearGrid}(time = 0 seconds, iteration = 0)
 
 ### Algorithm
 
-The SplitRungeKutta3 scheme follows Oceananigans' implementation. At the beginning of each
-full time step, the current state is cached via [`cache_current_fields!`](@ref ClimaSeaIce.cache_current_fields!).
-Then, three substeps are performed via [`rk_substep!`](@ref ClimaSeaIce.rk_substep!), each with a different
+The SplitRungeKutta3 scheme follows Oceananigans' implementation of the low-storage
+framework described by [Silvestri et al. 2026](@cite SilvestriEtAl2026). At the beginning of each
+full time step, the current state is cached via `cache_current_fields!`.
+Then, three substeps are performed via `rk_substep!`, each with a different
 time increment and weighting.
 
 Each substep performs the following operations in sequence:

--- a/examples/arctic_basin_seasonal_cycle.jl
+++ b/examples/arctic_basin_seasonal_cycle.jl
@@ -111,8 +111,8 @@ end
 
 # !!! note "Slightly wrong value for Stefan-Boltzmann constant"
 #
-#     Semtner (1976) uses a wrong value for the Stefan-Boltzmann constant
-#     (roughly 2% higher) to match the results of [Maykut & Untersteiner 1971](@cite MaykutUntersteiner1971).
+#     [Semtner1976](@citet) Semtner1976uses a wrong value for the Stefan-Boltzmann constant
+#     (roughly 2% higher) to match the results of [MaykutUntersteiner1971](@citet).
 #     We use here the same value here for comparison purposes.
 
 σ = 5.67e-8 * 1.02 # Wrong value, but used for comparison!

--- a/examples/ice_advected_on_coastline.jl
+++ b/examples/ice_advected_on_coastline.jl
@@ -40,7 +40,8 @@ arch = CPU()
 
 # ## Grid configuration
 #
-# We create a rectilinear grid with periodic boundaries in x and bounded boundaries in y:
+# We create a rectilinear grid with periodic boundaries in ``x`` and bounded
+# boundaries in ``y``:
 
 grid = RectilinearGrid(arch; size = (Nx, Ny),
                                 x = (-Lx/2, Lx/2),
@@ -96,19 +97,19 @@ immersed_v_bc = FluxBoundaryCondition(immersed_v_drag, discrete_form=true, param
 immersed_u_bc = ImmersedBoundaryCondition(top=nothing, bottom=nothing, west=nothing,  east=nothing,  south=immersed_u_bc, north=immersed_u_bc)
 immersed_v_bc = ImmersedBoundaryCondition(top=nothing, bottom=nothing, south=nothing, north=nothing, west=immersed_v_bc,  east=immersed_v_bc)
 
-u_bcs = FieldBoundaryConditions(grid, (Face(), Center(), nothing); 
+u_bcs = FieldBoundaryConditions(grid, (Face(), Center(), nothing);
                                 north = ValueBoundaryCondition(0),
                                 south = ValueBoundaryCondition(0),
                                 immersed = immersed_u_bc)
 
-v_bcs = FieldBoundaryConditions(grid, (Center(), Face(), nothing); 
+v_bcs = FieldBoundaryConditions(grid, (Center(), Face(), nothing);
                                 immersed = immersed_v_bc)
 
 # We define the model with WENO advection and no thermodynamics:
 
 model = SeaIceModel(grid;
                     advection = WENO(order=7),
-                    dynamics = dynamics,
+                    dynamics,
                     boundary_conditions = (; u=u_bcs, v=v_bcs),
                     ice_thermodynamics = nothing)
 
@@ -121,7 +122,7 @@ set!(model, ℵ = 1)
 #
 # We run the model for 3 days with a 5-minute time step:
 
-simulation = Simulation(model, Δt = 5minutes, stop_time=3days)
+simulation = Simulation(model, Δt=5minutes, stop_time=3days)
 
 # ## Collecting data
 #
@@ -143,7 +144,7 @@ function accumulate_timeseries(sim)
     push!(vtimeseries, deepcopy(Array(interior(v))))
 end
 
-simulation.callbacks[:save]     = Callback(accumulate_timeseries, IterationInterval(10))
+simulation.callbacks[:save] = Callback(accumulate_timeseries, IterationInterval(10))
 
 run!(simulation)
 

--- a/src/Rheologies/elasto_visco_plastic_rheology.jl
+++ b/src/Rheologies/elasto_visco_plastic_rheology.jl
@@ -50,8 +50,8 @@ struct IceStrength end
                                relaxation_strength = π^2,
                                pressure_formulation = ReplacementPressure())
 
-Constructs an `ElastoViscoPlasticRheology` object representing a "modified" elasto-visco-plastic
-rheology for slab sea ice dynamics that follows the implementation of
+Construct an `ElastoViscoPlasticRheology` object representing a modified
+elasto-visco-plastic rheology for sea-ice dynamics following
 [Kimmritz et al. 2017](@cite Kimmritz2017).
 The stress tensor is computed following the constitutive relation:
 ```math
@@ -74,30 +74,41 @@ The stresses are substepped with:
 σᵢⱼᵖ⁺¹ = σᵢⱼᵖ + (σᵢⱼᵖ⁺¹ - σᵢⱼᵖ) / α
 ```
 
-This formulation allows fast convergence in regions where α is small. Regions where
+This formulation allows fast convergence in regions where ``α`` is small. Regions where
 ``α`` is large correspond to regions where the ice is more solid and the convergence is slower.
-``α`` can be thougth of as a "pseudo substep number" or a "relaxation parameter".
+``α`` can be thought of as a "pseudo substep number" or a "relaxation parameter".
 If we are using a subcycling solver, then if ``α`` ≪ number of substeps, the convergence is faster.
 
 Arguments
 =========
 
-- `grid`: the `SlabSeaIceModel` grid
+- `grid`: The computational grid.
 
 Keyword Arguments
 =================
 
-- `ice_compressive_strength`: parameter expressing compressive strength (in Nm²). Default: `27500`.
-- `ice_compaction_hardening`: exponent coefficient for compaction hardening. Default: `20`.
-- `yield_curve_eccentricity`: eccentricity of the elliptic yield curve. Default: `2`.
-- `Δ_min`: Minimum value for the visco-plastic parameter. Limits the maximum viscosity of the ice,
-           transitioning the ice from a plastic to a viscous behaviour. Default: `1e-10`.
-- `min_relaxation_parameter`: Minimum value for the relaxation parameter `α`. Default: `30`.
-- `max_relaxation_parameter`: Maximum value for the relaxation parameter `α`. Default: `500`.
-- `relaxation_strength`: parameter controlling the strength of the relaxation parameter. The maximum value is `π²`;
-                         see [Kimmritz et al. 2017](@cite Kimmritz2017). Default: `π² / 2`.
-- `pressure_formulation`: can use `ReplacementPressure` or `IceStrength`. The replacement pressure formulation avoids
-                          ice motion in the absence of forcing. Default: `ReplacementPressure`.
+- `ice_compressive_strength`: Parameter expressing compressive strength
+                              (in N m⁻²). Default: `27500`.
+- `ice_compaction_hardening`: Exponent coefficient for compaction hardening.
+                              Default: `20`.
+- `yield_curve_eccentricity`: Eccentricity of the elliptic yield curve.
+                              Default: `2`.
+- `minimum_plastic_stress`: Minimum value for the visco-plastic parameter.
+                            Limits the maximum viscosity of the ice, transitioning
+                            the rheology from plastic to viscous behavior.
+                            Default: `2e-9`.
+- `min_relaxation_parameter`: Minimum value for the relaxation parameter `α`.
+                              Default: `50`.
+- `max_relaxation_parameter`: Maximum value for the relaxation parameter `α`.
+                              Default: `300`.
+- `relaxation_strength`: Parameter controlling the strength of the relaxation
+                         parameter. The maximum value is `π²`; see
+                         [Kimmritz et al. 2017](@cite Kimmritz2017).
+                         Default: `π²`.
+- `pressure_formulation`: Either `ReplacementPressure()` or `IceStrength()`.
+                          The replacement-pressure formulation avoids ice motion
+                          in the absence of forcing. Default:
+                          `ReplacementPressure()`.
 
 References
 ==========

--- a/src/SeaIceDynamics/sea_ice_momentum_equations.jl
+++ b/src/SeaIceDynamics/sea_ice_momentum_equations.jl
@@ -45,12 +45,24 @@ Keyword Arguments
 =================
 
 - `coriolis`: Parameters for the background rotation rate of the model.
-- `rheology`: The sea ice rheology model, default is `ElastoViscoPlasticRheology(eltype(grid))`.
+- `rheology`: The sea-ice rheology model. Default:
+              `ElastoViscoPlasticRheology(eltype(grid))`.
+- `top_momentum_stress`: Atmosphere-to-ice momentum stress, or an object that can
+                         be materialized into one. Default: `nothing`.
+- `bottom_momentum_stress`: Ocean-to-ice momentum stress, or an object that can
+                            be materialized into one. Default: `nothing`.
 - `free_drift`: The free drift velocities used when nonzero sea ice mass or concentration are below
                 the dynamical momentum thresholds. Default is `nothing`.
-- `solver`: The momentum solver to be used.
-- `minimum_concentration`: The minimum sea ice concentration above which the sea ice velocity is dynamically calculated; below this threshold nonzero sea ice moves with free drift, and roundoff-level concentration cells are set to zero. Default is `1e-3`.
-- `minimum_mass`: The minimum sea ice mass per area above which the sea ice velocity is dynamically calculated; below this threshold nonzero sea ice moves with free drift, and roundoff-level mass cells are set to zero. Default is `1.0 kg/m²`.
+- `solver`: Momentum solver used to advance the velocity field. Default:
+            `SplitExplicitSolver(grid; substeps = 150)`.
+- `minimum_concentration`: Minimum sea-ice concentration above which the velocity
+                           is evolved dynamically. Below this threshold, nonzero
+                           ice moves with free drift and roundoff-level
+                           concentration cells are set to zero. Default: `1e-3`.
+- `minimum_mass`: Minimum sea-ice mass per area above which the velocity is
+                  evolved dynamically. Below this threshold, nonzero ice moves
+                  with free drift and roundoff-level mass cells are set to zero.
+                  Default: `1.0 kg/m²`.
 """
 function SeaIceMomentumEquation(grid;
                                 coriolis = nothing,

--- a/src/SeaIceThermodynamics/HeatBoundaryConditions/boundary_fluxes.jl
+++ b/src/SeaIceThermodynamics/HeatBoundaryConditions/boundary_fluxes.jl
@@ -52,21 +52,36 @@ Base.show(io::IO, flux::FluxFunction) = print(io, summary(flux))
 """
     FluxFunction(func; parameters=nothing, top_temperature_dependent=false)
 
-Return `FluxFunction` representing a flux across an air-ice, air-snow, or ice-water interface.
-The flux is computed by `func` with the signature
+Return a `FluxFunction` representing a flux across an air-ice, air-snow, or
+ice-water interface.
+
+The wrapped callable `func` must have one of the following signatures:
 
 ```julia
 flux = func(i, j, grid, clock, top_temperature, model_fields)
 ```
 
-if `isnothing(parameters)`, or
+when `isnothing(parameters)`, or
 
 ```julia
 flux = func(i, j, grid, clock, top_temperature, model_fields, parameters)
 ```
 
-if `!isnothing(parameters)`. If `func` is `top_temperature_dependent`, then it will be recomputed
-during a diagnostic solve for the top temperature.
+when `!isnothing(parameters)`.
+
+Set `top_temperature_dependent = true` when the flux must be recomputed during
+the diagnostic solve for the surface temperature.
+
+Example
+=======
+
+```julia
+@inline sensible_heat_flux(i, j, grid, Tₛ, clock, fields, coefficient) =
+    coefficient * (fields.T_air[i, j, 1] - Tₛ)
+
+Q = FluxFunction(sensible_heat_flux; parameters = 15.0,
+                 top_temperature_dependent = true)
+```
 """
 function FluxFunction(func; parameters=nothing, top_temperature_dependent=false)
     T = top_temperature_dependent ? SurfaceTemperatureDependent() : Nothing

--- a/src/SeaIceThermodynamics/SeaIceThermodynamics.jl
+++ b/src/SeaIceThermodynamics/SeaIceThermodynamics.jl
@@ -38,9 +38,9 @@ Tₘ(S) = T₀ - m S ,
 
 where ``Tₘ(S)`` is the melting temperature as a function of salinity ``S``,
 ``T₀`` is the melting temperature of freshwater, and ``m`` is the ratio
-between the melting temperature and salinity (in other words the linear model
-should be thought of as defining ``m`` and could be written ``m ≡ (T₀ - Tₘ) / S``.
-The signs are arranged so that ``m > 0`` for saltwater).
+between the melting temperature and salinity (equivalently,
+``m ≡ (T₀ - Tₘ) / S``). The sign convention is chosen so that ``m > 0`` for
+saltwater, meaning the melting temperature decreases as salinity increases.
 
 The defaults assume that salinity is given in practical salinity units `psu` and
 temperature is in degrees Celsius.
@@ -90,6 +90,10 @@ end
 
 Return a representation of transitions between the solid and liquid phases
 of salty water: in other words, the freezing and melting of sea ice.
+
+`PhaseTransitions` stores the thermodynamic parameters shared by the slab sea-ice
+and snow parameterizations in `SeaIceModel`, including densities, heat
+capacities, a reference latent heat, and the liquidus relation.
 
 The latent heat of fusion ``ℒ(T)`` (more simply just "latent heat") is
 a function of temperature ``T`` via

--- a/src/SeaIceThermodynamics/SeaIceThermodynamics.jl
+++ b/src/SeaIceThermodynamics/SeaIceThermodynamics.jl
@@ -143,12 +143,12 @@ Return the per-mass latent heat of fusion of pure ice at temperature `T`,
 ℒ(T) = ℒ₀ + \\left(\\frac{ρ_ℓ c_ℓ}{ρ} - c\\right)(T - T₀) ,
 ```
 
-where `ρ`, `c` are the microscopic pure-ice density and heat capacity,
-`ρ_ℓ`, `c_ℓ` are the liquid density and heat capacity, and `T₀` is the
-reference temperature at which the reference latent heat `ℒ₀` is defined.
+where ``ρ``, ``c`` are the microscopic pure-ice density and heat capacity,
+``ρ_ℓ``, ``c_ℓ`` are the liquid density and heat capacity, and ``T₀`` is the
+reference temperature at which the reference latent heat ``ℒ₀`` is defined.
 
 This is the per-mass form of the volumetric expression
-`ρ ℒ(T) = ρ ℒ₀ + (ρ_ℓ c_ℓ - ρ c)(T - T₀)` (divided through by `ρ`).
+``ρ ℒ(T) = ρ ℒ₀ + (ρ_ℓ c_ℓ - ρ c)(T - T₀)`` (divided through by ``ρ``).
 
 The returned quantity is per unit mass of pure ice. To obtain energy per
 unit volume of a porous medium (snow or sea ice), multiply by the bulk

--- a/src/SeaIceThermodynamics/slab_sea_ice_thermodynamics.jl
+++ b/src/SeaIceThermodynamics/slab_sea_ice_thermodynamics.jl
@@ -61,12 +61,19 @@ Oceananigans.prognostic_fields(therm::SSIT) = NamedTuple()
 """
     SlabThermodynamics(grid; kw...)
 
-A minimal slab representation of a single sea-ice or snow layer. Stores
-the top surface temperature, top/bottom heat boundary conditions, the raw
-internal-flux coefficient (e.g. a `ConductiveFlux`), and the concentration
-evolution rule. Phase-transition parameters (densities, latent heats,
-liquidus) are stored at the `SeaIceModel` level and threaded into the
-tendency kernels via `model.phase_transitions`.
+A minimal slab representation of a single sea-ice or snow layer.
+
+The object stores:
+
+- the prognostic top surface temperature,
+- top and bottom heat boundary conditions,
+- an internal heat-flux model (for example `ConductiveFlux`), and
+- the concentration-evolution rule used when thermodynamic growth or melt
+  changes ice volume.
+
+Shared thermodynamic material properties such as densities, latent heat, and
+the liquidus relation are stored at the `SeaIceModel` level and threaded into
+the tendency kernels via `model.phase_transitions`.
 """
 function SlabThermodynamics(grid;
                             top_surface_temperature        = nothing,
@@ -185,6 +192,21 @@ ClimaSeaIce.SeaIceThermodynamics.flux_kernel(::MyFlux) = my_flux_kernel
 
 where `my_flux_kernel(i, j, grid, Tu, clock, fields, parameters)` returns a
 heat flux with `parameters.flux::MyFlux`.
+
+Minimal example:
+
+```julia
+struct MyFlux{T}
+    coefficient :: T
+end
+
+@inline function my_flux_kernel(i, j, grid, Tu, clock, fields, parameters)
+    flux = parameters.flux
+    return flux.coefficient * (fields.h[i, j, 1] - Tu)
+end
+
+ClimaSeaIce.SeaIceThermodynamics.flux_kernel(::MyFlux) = my_flux_kernel
+```
 
 Built-in dispatches:
 

--- a/src/sea_ice_model.jl
+++ b/src/sea_ice_model.jl
@@ -104,19 +104,29 @@ Keyword Arguments
                   included in the prognostic state as `S`. Default: 0 psu.
 - `sea_ice_density`: Bulk sea-ice density. Default: 900 kg m⁻³.
 - `snow_density`: Bulk snow density. Default: 330 kg m⁻³.
-- `phase_transitions`: Thermodynamic phase-transition parameters.
-- `top_heat_flux`: External top heat flux. Default: `nothing`.
-- `bottom_heat_flux`: External bottom heat flux. Default: 0 W m⁻².
+- `phase_transitions`: Thermodynamic phase-transition parameters shared by the
+                       ice and snow slabs. Default:
+                       `PhaseTransitions(eltype(grid))`.
+- `top_heat_flux`: External top heat flux, or tuple of fluxes, passed to the
+                   ice upper boundary condition. Default: `nothing`.
+- `bottom_heat_flux`: External bottom heat flux passed to the ice lower
+                      boundary condition. Default: `0` W m⁻².
 - `velocities`: Pre-existing velocity fields. If omitted, they are allocated by
-                the constructor. Default: `nothing`.
+                the constructor, possibly on an extended grid required by the
+                selected dynamics solver. Default: `nothing`.
 - `advection`: Advection scheme for prognostic tracers. Default: `nothing`.
 - `tracers`: Additional prognostic tracers.
-- `timestepper`: Time stepper specification passed to `TimeStepper`. Default: `:SplitRungeKutta3`.
+- `timestepper`: Time stepper specification passed to `TimeStepper`. Default:
+                 `:SplitRungeKutta3`.
 - `boundary_conditions`: Boundary conditions for allocated prognostic fields.
-- `ice_thermodynamics`: Ice thermodynamics model. Default: `sea_ice_slab_thermodynamics(grid)`.
-- `snow_thermodynamics`: Optional snow thermodynamics model.
-- `snowfall`: Snowfall forcing. Defaults to 0, but can be also a `Field` or a `FieldTimeSeries`.
-- `dynamics`: Optional sea-ice dynamics model, for example, `SeaIceMomentumEquation(grid)`.
+- `ice_thermodynamics`: Ice thermodynamics model. Default:
+                        `sea_ice_slab_thermodynamics(grid)`.
+- `snow_thermodynamics`: Optional snow thermodynamics model. When provided, the
+                         model allocates prognostic snow thickness `hs`.
+- `snowfall`: Snowfall forcing applied only when `snow_thermodynamics` is
+              present. May be a constant, `Field`, or `FieldTimeSeries`.
+- `dynamics`: Optional sea-ice dynamics model, for example,
+              `SeaIceMomentumEquation(grid)`.
 - `forcing`: Additional model forcing passed through `model_forcing`.
 """
 function SeaIceModel(grid;

--- a/src/sea_ice_rk_substep.jl
+++ b/src/sea_ice_rk_substep.jl
@@ -13,10 +13,19 @@ Oceananigans.TimeSteppers.step_lagrangian_particles!(model::SeaIceModel, Δτ) =
 Cache the current prognostic fields (ice thickness `h`, ice concentration `ℵ`, and any additional
 tracers) into the timestepper's `Ψ⁻` storage before performing a Runge-Kutta substep.
 
-This function is called by Oceananigans' `SplitRungeKuttaTimeStepper` at the beginning of each
-full time step to store the state `Uⁿ` that is needed for computing the RK3 weighted average.
+This function is called by Oceananigans' `SplitRungeKuttaTimeStepper` at the beginning
+of each full time step to store the state `Uⁿ` that is needed for computing the
+RK3 weighted average in the low-storage framework of [Silvestri et al. 2026](@cite SilvestriEtAl2026).
 
-See also: [`rk_substep!`](@ref), [`dynamic_time_step!`](@ref)
+See also: [`rk_substep!`],
+[`dynamic_time_step!`](@ref ClimaSeaIce.dynamic_time_step!)
+
+References
+==========
+
+- Silvestri, S., Campin, J.-M., Wagner, G. L., Constantinou, N. C., Lee, X. K., and Ferrari, R. (2026). A
+    low-storage Runge-Kutta framework for nonlinear free-surface ocean models. J. Adv. Model. Earth Sy. Submitted
+    in April 2026. doi:10.22541/essoar.15002225/v1.
 """
 function Oceananigans.TimeSteppers.cache_current_fields!(model::RKSeaIceModel)
     previous_fields = model.timestepper.Ψ⁻
@@ -36,7 +45,7 @@ end
 """
     rk_substep!(model::RKSeaIceModel, Δτ, callbacks)
 
-Perform a single Runge-Kutta substep for the sea ice model, advancing the state by `Δτ`.
+Perform a single Runge--Kutta substep for the sea ice model, advancing the state by `Δτ`.
 
 The substep consists of three sequential operations:
 
@@ -51,7 +60,8 @@ The substep consists of three sequential operations:
    scheme via `time_step_momentum!`.
 
 This function is called by Oceananigans' `SplitRungeKuttaTimeStepper` for each of the
-three RK3 substeps within a full time step.
+three RK3 substeps within a full time step, following the low-storage framework
+of [Silvestri et al. 2026](@cite SilvestriEtAl2026).
 
 Arguments
 =========
@@ -59,7 +69,13 @@ Arguments
 - `Δτ`: The substep time increment (a fraction of the full time step `Δt`).
 - `callbacks`: Callbacks to execute during the substep (currently unused).
 
-See also: [`cache_current_fields!`](@ref), [`dynamic_time_step!`](@ref)
+See also: `cache_current_fields!`,
+[`dynamic_time_step!`](@ref ClimaSeaIce.dynamic_time_step!)
+
+References
+==========
+
+- Silvestri, S., Campin, J.-M., Wagner, G. L., Constantinou, N. C., Lee, X. K., and Ferrari, R. (2026). A low-storage Runge-Kutta framework for nonlinear free-surface ocean models. J. Adv. Model. Earth Sy. Submitted in April 2026. doi:10.22541/essoar.15002225/v1.
 """
 function Oceananigans.TimeSteppers.rk_substep!(model::RKSeaIceModel, Δτ, callbacks)
 
@@ -80,19 +96,20 @@ end
     dynamic_time_step!(model::RKSeaIceModel, Δt)
 
 Update ice thickness `h` and concentration `ℵ` based on advective tendencies stored in
-`model.timestepper.Gⁿ` for a Runge-Kutta substep.
+`model.timestepper.Gⁿ` for a Runge--Kutta substep.
 
 Unlike the Forward Euler version, this function uses the cached previous state `Ψ⁻`
-(stored by [`cache_current_fields!`](@ref)) as the base state for the update:
+(stored by `cache_current_fields!`)
+as the base state for the update:
 
 ```math
 \\begin{align*}
-h^{n+1} = h^n + Δt G_h^n \\\\
-ℵ^{n+1} = ℵ^n + Δt G_ℵ^n
+hⁿ⁺¹ = hⁿ + Δt \\, Gⁿ_h \\\\
+ℵⁿ⁺¹ = ℵⁿ + Δt \\, Gⁿ_ℵ
 \\end{align*}
 ```
 
-where `hⁿ` and `ℵⁿ` are retrieved from `model.timestepper.Ψ⁻`.
+where ``hⁿ`` and ``ℵⁿ`` are retrieved from `model.timestepper.Ψ⁻`.
 
 The kernel `_dynamic_step_tracers!` also handles:
 - Clipping negative thickness and concentration values
@@ -102,10 +119,17 @@ The kernel `_dynamic_step_tracers!` also handles:
 
 Arguments
 =========
-- `model`: A `SeaIceModel` using `SplitRungeKuttaTimeStepper`.
+- `model`: A `SeaIceModel` using `SplitRungeKuttaTimeStepper`, following the
+           low-storage framework of [Silvestri et al. 2026](@cite SilvestriEtAl2026).
 - `Δt`: The time increment for this substep.
 
-See also: [`rk_substep!`](@ref), [`cache_current_fields!`](@ref)
+See also: `rk_substep!`,
+`cache_current_fields!`
+
+References
+==========
+
+- Silvestri, S., Campin, J.-M., Wagner, G. L., Constantinou, N. C., Lee, X. K., and Ferrari, R. (2026). A low-storage Runge-Kutta framework for nonlinear free-surface ocean models. J. Adv. Model. Earth Sy. Submitted in April 2026. doi:10.22541/essoar.15002225/v1.
 """
 function dynamic_time_step!(model::RKSeaIceModel, Δt)
     grid = model.grid

--- a/src/sea_ice_rk_substep.jl
+++ b/src/sea_ice_rk_substep.jl
@@ -11,14 +11,13 @@ Oceananigans.TimeSteppers.step_lagrangian_particles!(model::SeaIceModel, Δτ) =
     cache_current_fields!(model::RKSeaIceModel)
 
 Cache the current prognostic fields (ice thickness `h`, ice concentration `ℵ`, and any additional
-tracers) into the timestepper's `Ψ⁻` storage before performing a Runge-Kutta substep.
+tracers) into the timestepper's `Ψ⁻` storage before performing a Runge--Kutta substep.
 
 This function is called by Oceananigans' `SplitRungeKuttaTimeStepper` at the beginning
 of each full time step to store the state `Uⁿ` that is needed for computing the
 RK3 weighted average in the low-storage framework of [Silvestri et al. 2026](@cite SilvestriEtAl2026).
 
-See also: [`rk_substep!`],
-[`dynamic_time_step!`](@ref ClimaSeaIce.dynamic_time_step!)
+See also: `rk_substep!`, [`dynamic_time_step!`](@ref ClimaSeaIce.dynamic_time_step!).
 
 References
 ==========
@@ -45,12 +44,14 @@ end
 """
     rk_substep!(model::RKSeaIceModel, Δτ, callbacks)
 
-Perform a single Runge--Kutta substep for the sea ice model, advancing the state by `Δτ`.
+Perform a single Runge--Kutta substep for the sea-ice model, advancing the
+state by `Δτ`.
 
 The substep consists of three sequential operations:
 
-1. **Dynamic step**: Compute advective tendencies and update ice thickness `h` and
-   concentration `ℵ` via [`dynamic_time_step!`](@ref).
+1. **Dynamic step**: Compute advective tendencies and update ice thickness `h`
+   and concentration `ℵ` via [`dynamic_time_step!`](@ref
+   ClimaSeaIce.dynamic_time_step!).
 
 2. **Thermodynamic step**: Apply column physics (melting/freezing) via
    `thermodynamic_time_step!`. This step is performed all at once since thermodynamics
@@ -70,7 +71,7 @@ Arguments
 - `callbacks`: Callbacks to execute during the substep (currently unused).
 
 See also: `cache_current_fields!`,
-[`dynamic_time_step!`](@ref ClimaSeaIce.dynamic_time_step!)
+[`dynamic_time_step!`](@ref ClimaSeaIce.dynamic_time_step!).
 
 References
 ==========
@@ -95,12 +96,12 @@ end
 """
     dynamic_time_step!(model::RKSeaIceModel, Δt)
 
-Update ice thickness `h` and concentration `ℵ` based on advective tendencies stored in
-`model.timestepper.Gⁿ` for a Runge--Kutta substep.
+Update ice thickness `h` and concentration `ℵ` using the advective tendencies
+stored in `model.timestepper.Gⁿ` for a Runge--Kutta substep.
 
-Unlike the Forward Euler version, this function uses the cached previous state `Ψ⁻`
-(stored by `cache_current_fields!`)
-as the base state for the update:
+Unlike the Forward Euler version, this method updates the state from the cached
+previous state `Ψ⁻` (stored by `cache_current_fields!`) rather than from the
+already-updated fields:
 
 ```math
 \\begin{align*}
@@ -123,8 +124,7 @@ Arguments
            low-storage framework of [Silvestri et al. 2026](@cite SilvestriEtAl2026).
 - `Δt`: The time increment for this substep.
 
-See also: `rk_substep!`,
-`cache_current_fields!`
+See also: `rk_substep!`, `cache_current_fields!`.
 
 References
 ==========


### PR DESCRIPTION
## Summary

Improve documentation references and clean up public-facing docstrings across the sea-ice model, thermodynamics, rheology, and timestepping APIs.

## Changes

- add the Silvestri et al. 2026 low-storage Runge-Kutta citation to the docs bibliography
- cite the low-storage Runge-Kutta framework from the timestepping page and RK substep docstrings
- avoid broken Documenter cross-references for externally-owned timestepper methods by using safer prose references
- make `draft = false` explicit in `docs/make.jl` for easier local toggling during docs debugging
- improve public docstrings for:
  - `SeaIceMomentumEquation`
  - `ElastoViscoPlasticRheology`
  - `LinearLiquidus`
  - `PhaseTransitions`
  - `SlabThermodynamics`
  - `FluxFunction`
  - `SeaIceModel`
  - Runge-Kutta substep internals
- fix stale or misleading wording in docstrings, including:
  - stale `SlabSeaIceModel` references
  - undocumented momentum-stress keywords
  - mismatched keyword names like `minimum_plastic_stress`
  - unclear snowfall / snow thermodynamics behavior
  - inconsistent Runge-Kutta wording and math formatting

## Validation

- updated docs references consistently across the bibliography, timestepping docs, and RK substep docstrings
- removed fragile external-owner `@ref` links that were triggering Documenter warnings
- reviewed the revised constructor and method docstrings for keyword/signature consistency
