### PR TITLE
(0.6.0) Add thermodynamics mass fluxes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,31 @@ jobs:
         env:
           TEST_GROUP: "enthalpy"
 
+  mass_fluxes:
+    name: Thermodynamic Mass Fluxes - Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.12'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v5
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        env:
+          TEST_GROUP: "mass_fluxes"
+
   snow:
     name: Snow Thermodynamics - Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaSeaIce"
 uuid = "6ba0ff68-24e6-4315-936c-2e99227c95a4"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.5.6"
+version = "0.6.0"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/SeaIceThermodynamics/thermodynamic_time_step.jl
+++ b/src/SeaIceThermodynamics/thermodynamic_time_step.jl
@@ -23,7 +23,7 @@ function thermodynamic_time_step!(model, ice_thermodynamics::SlabThermodynamics,
             model.sea_ice_density,
             model.external_heat_fluxes.top,
             model.external_heat_fluxes.bottom,
-            model.thermodynamic_mass_fluxes,
+            model.mass_fluxes,
             fields(model))
 
     return nothing
@@ -53,7 +53,7 @@ function thermodynamic_time_step!(model,
             model.external_heat_fluxes.bottom,
             model.snow_thickness,
             model.snowfall,
-            model.thermodynamic_mass_fluxes,
+            model.mass_fluxes,
             fields(model))
 
     return nothing
@@ -83,7 +83,7 @@ end
                                                sea_ice_density,
                                                top_external_heat_flux,
                                                bottom_external_heat_flux,
-                                               thermodynamic_mass_fluxes,
+                                               mass_fluxes,
                                                model_fields)
 
     i, j = @index(Global, NTuple)
@@ -111,9 +111,9 @@ end
         ice_concentration[i, j, 1] = ℵⁿ⁺¹
         ice_thickness[i, j, 1]     = hⁿ⁺¹
 
-        thermodynamic_mass_fluxes.ice[i, j, 1]  = ρi * (hⁿ⁺¹ * ℵⁿ⁺¹ - hⁿ * ℵⁿ) / Δt
-        thermodynamic_mass_fluxes.snow[i, j, 1] = 0
-        thermodynamic_mass_fluxes.intercepted_snowfall[i, j, 1] = 0
+        mass_fluxes.thermodynamics.ice[i, j, 1]  = ρi * (hⁿ⁺¹ * ℵⁿ⁺¹ - hⁿ * ℵⁿ) / Δt
+        mass_fluxes.thermodynamics.snow[i, j, 1] = 0
+        mass_fluxes.intercepted_snowfall[i, j, 1] = 0
     end
 end
 
@@ -143,7 +143,7 @@ end
                                                    bottom_external_heat_flux,
                                                    snow_thickness,
                                                    snowfall,
-                                                   thermodynamic_mass_fluxes,
+                                                   mass_fluxes,
                                                    model_fields)
 
     i, j = @index(Global, NTuple)
@@ -154,8 +154,8 @@ end
     @inbounds hsⁿ = snow_thickness[i, j, 1]
 
     # Per-cell volumes before the step, captured before `hsⁿ` is rebased below
-    Vᵢⁿ = hiⁿ * ℵⁿ
-    Vₛⁿ = hsⁿ * ℵⁿ
+    Viⁿ = hiⁿ * ℵⁿ
+    Vsⁿ = hsⁿ * ℵⁿ
 
     consolidated_ice = hiⁿ ≥ hᶜ
 
@@ -287,13 +287,13 @@ end
     @inbounds ice_thickness[i, j, 1]     = hiⁿ⁺¹
     @inbounds snow_thickness[i, j, 1]    = hs⁺
 
-    # Snowfall mass deposited on top of the ice 
-    Pₛᵃᵇˢ = ρs * Gs⁺ * ℵⁿ⁺¹
+    # Snowfall mass deposited on top of the ice
+    Psᵃᵇˢ = ρs * Gs⁺ * ℵⁿ⁺¹
 
     @inbounds begin
-        thermodynamic_mass_fluxes.ice[i, j, 1]  = ρi * (hiⁿ⁺¹ * ℵⁿ⁺¹ - Vᵢⁿ) / Δt
-        thermodynamic_mass_fluxes.snow[i, j, 1] = ρs * (hs⁺ * ℵⁿ⁺¹ - Vₛⁿ) / Δt - Pₛᵃᵇˢ
-        thermodynamic_mass_fluxes.intercepted_snowfall[i, j, 1] = Pₛᵃᵇˢ
+        mass_fluxes.thermodynamics.ice[i, j, 1]  = ρi * (hiⁿ⁺¹ * ℵⁿ⁺¹ - Viⁿ) / Δt
+        mass_fluxes.thermodynamics.snow[i, j, 1] = ρs * (hs⁺ * ℵⁿ⁺¹ - Vsⁿ) / Δt - Psᵃᵇˢ
+        mass_fluxes.intercepted_snowfall[i, j, 1] = Psᵃᵇˢ
     end
 end
 

--- a/src/SeaIceThermodynamics/thermodynamic_time_step.jl
+++ b/src/SeaIceThermodynamics/thermodynamic_time_step.jl
@@ -23,6 +23,7 @@ function thermodynamic_time_step!(model, ice_thermodynamics::SlabThermodynamics,
             model.sea_ice_density,
             model.external_heat_fluxes.top,
             model.external_heat_fluxes.bottom,
+            model.thermodynamic_mass_fluxes,
             fields(model))
 
     return nothing
@@ -52,6 +53,7 @@ function thermodynamic_time_step!(model,
             model.external_heat_fluxes.bottom,
             model.snow_thickness,
             model.snowfall,
+            model.thermodynamic_mass_fluxes,
             fields(model))
 
     return nothing
@@ -81,6 +83,7 @@ end
                                                sea_ice_density,
                                                top_external_heat_flux,
                                                bottom_external_heat_flux,
+                                               thermodynamic_mass_fluxes,
                                                model_fields)
 
     i, j = @index(Global, NTuple)
@@ -102,8 +105,16 @@ end
 
     hⁿ⁺¹, ℵⁿ⁺¹ = ice_volume_update(ice_thermodynamics, ∂t_V, hⁿ, ℵⁿ, hᶜ, Δt)
 
-    @inbounds ice_concentration[i, j, 1] = ℵⁿ⁺¹
-    @inbounds ice_thickness[i, j, 1]     = hⁿ⁺¹
+    @inbounds begin
+        ρi = sea_ice_density[i, j, 1]
+        
+        ice_concentration[i, j, 1] = ℵⁿ⁺¹
+        ice_thickness[i, j, 1]     = hⁿ⁺¹
+
+        thermodynamic_mass_fluxes.ice[i, j, 1]  = ρi * (hⁿ⁺¹ * ℵⁿ⁺¹ - hⁿ * ℵⁿ) / Δt
+        thermodynamic_mass_fluxes.snow[i, j, 1] = 0
+        thermodynamic_mass_fluxes.intercepted_snowfall[i, j, 1] = 0
+    end
 end
 
 #####
@@ -132,6 +143,7 @@ end
                                                    bottom_external_heat_flux,
                                                    snow_thickness,
                                                    snowfall,
+                                                   thermodynamic_mass_fluxes,
                                                    model_fields)
 
     i, j = @index(Global, NTuple)
@@ -140,6 +152,10 @@ end
     @inbounds ℵⁿ  = ice_concentration[i, j, 1]
     @inbounds hᶜ  = ice_consolidation_thickness[i, j, 1]
     @inbounds hsⁿ = snow_thickness[i, j, 1]
+
+    # Per-cell volumes before the step, captured before `hsⁿ` is rebased below
+    Vᵢⁿ = hiⁿ * ℵⁿ
+    Vₛⁿ = hsⁿ * ℵⁿ
 
     consolidated_ice = hiⁿ ≥ hᶜ
 
@@ -270,6 +286,15 @@ end
     @inbounds ice_concentration[i, j, 1] = ℵⁿ⁺¹
     @inbounds ice_thickness[i, j, 1]     = hiⁿ⁺¹
     @inbounds snow_thickness[i, j, 1]    = hs⁺
+
+    # Snowfall mass deposited on top of the ice 
+    Pₛᵃᵇˢ = ρs * Gs⁺ * ℵⁿ⁺¹
+
+    @inbounds begin
+        thermodynamic_mass_fluxes.ice[i, j, 1]  = ρi * (hiⁿ⁺¹ * ℵⁿ⁺¹ - Vᵢⁿ) / Δt
+        thermodynamic_mass_fluxes.snow[i, j, 1] = ρs * (hs⁺ * ℵⁿ⁺¹ - Vₛⁿ) / Δt - Pₛᵃᵇˢ
+        thermodynamic_mass_fluxes.intercepted_snowfall[i, j, 1] = Pₛᵃᵇˢ
+    end
 end
 
 #####

--- a/src/sea_ice_model.jl
+++ b/src/sea_ice_model.jl
@@ -43,9 +43,8 @@ struct SeaIceModel{GR, TD, SNT, D, TS, CL, U, T, IT, IC, SNH, ID, SND, PT, CT, S
     # External boundary conditions
     external_heat_fluxes :: STF
     snowfall :: SP
-    # Diagnostics (kg m⁻² s⁻¹): `ice`/`snow` are per-step mass rates exchanged with the ocean
-    # (positive = gained from the ocean); `intercepted_snowfall` is the snowfall absorbed by the ice.
-    thermodynamic_mass_fluxes :: MFX
+    # Diagnostics (kg m⁻² s⁻¹)
+    mass_fluxes :: MFX
     # Numerics
     timestepper :: TS
     advection :: A
@@ -91,6 +90,12 @@ equations, and optional snow thermodynamics.
 The model evolves sea-ice thickness `h`, concentration `ℵ`, optional salinity
 `S`, optional snow thickness `hs`, and, when `dynamics` is provided, the
 horizontal ice velocity components `u` and `v`.
+
+The field `mass_fluxes` holds three diagnostics (kg m⁻² s⁻¹) written by the thermodynamic step:
+`mass_fluxes.thermodynamics.ice` and `mass_fluxes.thermodynamics.snow`, the per-step mass tendencies
+of the ice and snow slabs (their sum is the mass exchanged with the ocean), and
+`mass_fluxes.intercepted_snowfall`, the snowfall absorbed by the ice. These are excluded from
+`fields(model)` and the prognostic state.
 
 Arguments
 =========
@@ -262,9 +267,9 @@ function SeaIceModel(grid;
     external_heat_fluxes = (top = top_heat_flux,
                             bottom = bottom_heat_flux)
 
-    thermodynamic_mass_fluxes = (ice  = Field{Center, Center, Nothing}(grid),
-                                 snow = Field{Center, Center, Nothing}(grid),
-                                 intercepted_snowfall = Field{Center, Center, Nothing}(grid))
+    mass_fluxes = (thermodynamics = (ice  = Field{Center, Center, Nothing}(grid),
+                                     snow = Field{Center, Center, Nothing}(grid)),
+                   intercepted_snowfall = Field{Center, Center, Nothing}(grid))
 
     arch = architecture(grid)
 
@@ -286,7 +291,7 @@ function SeaIceModel(grid;
                        dynamics,
                        external_heat_fluxes,
                        snowfall,
-                       thermodynamic_mass_fluxes,
+                       mass_fluxes,
                        timestepper,
                        advection)
 end
@@ -377,6 +382,11 @@ function Oceananigans.TimeSteppers.update_state!(model::SIM, callbacks=[])
         mask_immersed_field_xy!(field, k=size(model.grid, 3))
         fill_halo_regions!(field, model.clock, fields(model))
     end
+
+    Nz = size(model.grid, 3)
+    mask_immersed_field_xy!(model.mass_fluxes.thermodynamics.ice,   k=Nz)
+    mask_immersed_field_xy!(model.mass_fluxes.thermodynamics.snow,  k=Nz)
+    mask_immersed_field_xy!(model.mass_fluxes.intercepted_snowfall, k=Nz)
 
     update_model_field_time_series!(model, model.clock)
 

--- a/src/sea_ice_model.jl
+++ b/src/sea_ice_model.jl
@@ -19,7 +19,7 @@ using .SeaIceThermodynamics.HeatBoundaryConditions: flux_summary
 @inline instantiate(T::DataType) = T()
 @inline instantiate(T) = T
 
-struct SeaIceModel{GR, TD, SNT, D, TS, CL, U, T, IT, IC, SNH, ID, SND, PT, CT, SP, STF, A, F, Arch} <: AbstractModel{TS, Arch}
+struct SeaIceModel{GR, TD, SNT, D, TS, CL, U, T, IT, IC, SNH, ID, SND, PT, CT, SP, MFX, STF, A, F, Arch} <: AbstractModel{TS, Arch}
     architecture :: Arch
     grid :: GR
     clock :: CL
@@ -43,6 +43,9 @@ struct SeaIceModel{GR, TD, SNT, D, TS, CL, U, T, IT, IC, SNH, ID, SND, PT, CT, S
     # External boundary conditions
     external_heat_fluxes :: STF
     snowfall :: SP
+    # Diagnostics (kg m⁻² s⁻¹): `ice`/`snow` are per-step mass rates exchanged with the ocean
+    # (positive = gained from the ocean); `intercepted_snowfall` is the snowfall absorbed by the ice.
+    thermodynamic_mass_fluxes :: MFX
     # Numerics
     timestepper :: TS
     advection :: A
@@ -259,6 +262,10 @@ function SeaIceModel(grid;
     external_heat_fluxes = (top = top_heat_flux,
                             bottom = bottom_heat_flux)
 
+    thermodynamic_mass_fluxes = (ice  = Field{Center, Center, Nothing}(grid),
+                                 snow = Field{Center, Center, Nothing}(grid),
+                                 intercepted_snowfall = Field{Center, Center, Nothing}(grid))
+
     arch = architecture(grid)
 
     return SeaIceModel(arch,
@@ -279,6 +286,7 @@ function SeaIceModel(grid;
                        dynamics,
                        external_heat_fluxes,
                        snowfall,
+                       thermodynamic_mass_fluxes,
                        timestepper,
                        advection)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,10 @@ if TEST_GROUP == "all" || TEST_GROUP == "snow"
     include("test_snow_thermodynamics.jl")
 end
 
+if TEST_GROUP == "all" || TEST_GROUP == "mass_fluxes"
+    include("test_thermodynamic_mass_fluxes.jl")
+end
+
 if TEST_GROUP == "all" || TEST_GROUP == "energy_conservation"
     include("test_energy_conservation.jl")
 end

--- a/test/test_thermodynamic_mass_fluxes.jl
+++ b/test/test_thermodynamic_mass_fluxes.jl
@@ -2,10 +2,10 @@ using ClimaSeaIce
 using Oceananigans
 using Test
 
-# The thermodynamic kernels overwrite `model.thermodynamic_mass_fluxes` (kg m⁻² s⁻¹) on every call.
+# The thermodynamic kernels overwrite `model.mass_fluxes` (kg m⁻² s⁻¹) on every call.
 # Mass closure identity (thermodynamics only, no advection):
 #
-#     ∂t(ρᵢ h ℵ + ρₛ hs ℵ) = ice + snow + intercepted_snowfall
+#     ∂t(ρᵢ h ℵ + ρₛ hs ℵ) = thermodynamics.ice + thermodynamics.snow + intercepted_snowfall
 #
 # With the SplitRungeKutta3 stepper every substep re-bases the prognostic state from Ψ⁻ and the final
 # substep advances the full Δt, so the fluxes recorded by the last call match the full-step mass change.
@@ -34,13 +34,17 @@ function mass_flux_closure(model, Δt)
     time_step!(model, Δt)
     Mi⁺, Ms⁺ = column_masses(model)
 
-    fluxes = model.thermodynamic_mass_fluxes
-    total = column_value(fluxes.ice) + column_value(fluxes.snow) + column_value(fluxes.intercepted_snowfall)
+    fluxes = model.mass_fluxes
+    total = column_value(fluxes.thermodynamics.ice) +
+            column_value(fluxes.thermodynamics.snow) +
+            column_value(fluxes.intercepted_snowfall)
     expected = ((Mi⁺ + Ms⁺) - (Mi⁻ + Ms⁻)) / Δt
 
     return total, expected
 end
 
+# Absolute tolerance for the closure identity, scaled by the flux magnitude. The 1e-12 floor assumes
+# Float64 grids; for lower-precision grids it should scale with `eps(eltype(grid))`.
 closure_tolerance(expected) = 1e-12 * max(1, abs(expected))
 
 @testset "Thermodynamic mass fluxes: bare ice [$timestepper]" for timestepper in (:ForwardEuler, :SplitRungeKutta3)
@@ -52,11 +56,11 @@ closure_tolerance(expected) = 1e-12 * max(1, abs(expected))
         set!(model, h=1, ℵ=1)
 
         total, expected = mass_flux_closure(model, Δt)
-        fluxes = model.thermodynamic_mass_fluxes
+        fluxes = model.mass_fluxes
 
         @test total ≈ expected atol=closure_tolerance(expected)
-        @test column_value(fluxes.ice) > 0
-        @test column_value(fluxes.snow) == 0
+        @test column_value(fluxes.thermodynamics.ice) > 0
+        @test column_value(fluxes.thermodynamics.snow) == 0
         @test column_value(fluxes.intercepted_snowfall) == 0
     end
 
@@ -66,11 +70,11 @@ closure_tolerance(expected) = 1e-12 * max(1, abs(expected))
         set!(model, h=1, ℵ=1)
 
         total, expected = mass_flux_closure(model, Δt)
-        fluxes = model.thermodynamic_mass_fluxes
+        fluxes = model.mass_fluxes
 
         @test total ≈ expected atol=closure_tolerance(expected)
-        @test column_value(fluxes.ice) < 0
-        @test column_value(fluxes.snow) == 0
+        @test column_value(fluxes.thermodynamics.ice) < 0
+        @test column_value(fluxes.thermodynamics.snow) == 0
         @test column_value(fluxes.intercepted_snowfall) == 0
     end
 
@@ -83,6 +87,20 @@ closure_tolerance(expected) = 1e-12 * max(1, abs(expected))
 
         @test column_value(model.ice_thickness) == 0
         @test column_value(model.ice_concentration) == 0
+        @test total ≈ expected atol=closure_tolerance(expected)
+    end
+
+    @testset "Partial concentration freezing" begin
+        # Starting below full cover exercises the lateral-growth concentration path (ℵ increases).
+        grid = RectilinearGrid(size=(), topology=(Flat, Flat, Flat))
+        model = SeaIceModel(grid; top_heat_flux = 300, bottom_heat_flux = 10, timestepper)
+        set!(model, h=1, ℵ=0.95)
+
+        total, expected = mass_flux_closure(model, Δt)
+        fluxes = model.mass_fluxes
+
+        @test column_value(model.ice_concentration) > 0.95
+        @test column_value(fluxes.thermodynamics.ice) > 0
         @test total ≈ expected atol=closure_tolerance(expected)
     end
 end
@@ -102,12 +120,12 @@ end
         set!(model, h=1, ℵ=1, hs=0.1)
 
         total, expected = mass_flux_closure(model, Δt)
-        fluxes = model.thermodynamic_mass_fluxes
+        fluxes = model.mass_fluxes
         ℵ⁺ = column_value(model.ice_concentration)
 
         @test total ≈ expected atol=closure_tolerance(expected)
         @test column_value(fluxes.intercepted_snowfall) ≈ Ps * ℵ⁺ atol=1e-12 * Ps
-        @test column_value(fluxes.ice) > 0
+        @test column_value(fluxes.thermodynamics.ice) > 0
     end
 
     @testset "Melting" begin
@@ -121,12 +139,12 @@ end
         set!(model, h=1, ℵ=1, hs=0.1)
 
         total, expected = mass_flux_closure(model, Δt)
-        fluxes = model.thermodynamic_mass_fluxes
+        fluxes = model.mass_fluxes
         ℵ⁺ = column_value(model.ice_concentration)
 
         @test total ≈ expected atol=closure_tolerance(expected)
         @test column_value(fluxes.intercepted_snowfall) ≈ Ps * ℵ⁺ atol=1e-12 * Ps
-        @test column_value(fluxes.snow) < 0 # top melt removes snow faster than snowfall replenishes it
+        @test column_value(fluxes.thermodynamics.snow) < 0 # top melt removes snow faster than snowfall replenishes it
     end
 
     @testset "Melt to extinction" begin
@@ -146,4 +164,32 @@ end
         @test column_value(model.snow_thickness) == 0
         @test total ≈ expected atol=closure_tolerance(expected)
     end
+end
+
+# The thermodynamic kernels write the diagnostics on every column, including immersed (land) cells;
+# `update_state!` must mask them so land reports zero exchange rather than a phantom flux.
+@testset "Thermodynamic mass fluxes: immersed masking [$timestepper]" for timestepper in (:ForwardEuler, :SplitRungeKutta3)
+    Δt = 3600
+
+    underlying_grid = RectilinearGrid(size=(2, 1, 1), x=(0, 2), y=(0, 1), z=(-1, 0),
+                                      topology=(Bounded, Bounded, Bounded))
+
+    # Column i=1 is land (bottom at the surface), column i=2 is ocean.
+    bottom(x, y) = x < 1 ? 0.0 : -1.0
+    grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBottom(bottom))
+
+    model = SeaIceModel(grid; top_heat_flux = 100, bottom_heat_flux = 10, timestepper)
+    set!(model, h=1, ℵ=1)
+
+    time_step!(model, Δt)
+
+    fluxes = model.mass_fluxes
+    ice  = interior(fluxes.thermodynamics.ice)
+    snow = interior(fluxes.thermodynamics.snow)
+    snowfall = interior(fluxes.intercepted_snowfall)
+
+    @test ice[1, 1, 1]  == 0   # land column masked
+    @test snow[1, 1, 1] == 0
+    @test snowfall[1, 1, 1] == 0
+    @test ice[2, 1, 1]  != 0   # ocean column freezes
 end

--- a/test/test_thermodynamic_mass_fluxes.jl
+++ b/test/test_thermodynamic_mass_fluxes.jl
@@ -1,0 +1,149 @@
+using ClimaSeaIce
+using Oceananigans
+using Test
+
+# The thermodynamic kernels overwrite `model.thermodynamic_mass_fluxes` (kg m⁻² s⁻¹) on every call.
+# Mass closure identity (thermodynamics only, no advection):
+#
+#     ∂t(ρᵢ h ℵ + ρₛ hs ℵ) = ice + snow + intercepted_snowfall
+#
+# With the SplitRungeKutta3 stepper every substep re-bases the prognostic state from Ψ⁻ and the final
+# substep advances the full Δt, so the fluxes recorded by the last call match the full-step mass change.
+
+column_value(f) = f[1, 1, 1]
+
+function column_masses(model)
+    ρi = column_value(model.sea_ice_density)
+    h  = column_value(model.ice_thickness)
+    ℵ  = column_value(model.ice_concentration)
+    Mi = ρi * h * ℵ
+
+    Ms = if isnothing(model.snow_thickness)
+        zero(Mi)
+    else
+        ρs = column_value(model.snow_density)
+        hs = column_value(model.snow_thickness)
+        ρs * hs * ℵ
+    end
+
+    return Mi, Ms
+end
+
+function mass_flux_closure(model, Δt)
+    Mi⁻, Ms⁻ = column_masses(model)
+    time_step!(model, Δt)
+    Mi⁺, Ms⁺ = column_masses(model)
+
+    fluxes = model.thermodynamic_mass_fluxes
+    total = column_value(fluxes.ice) + column_value(fluxes.snow) + column_value(fluxes.intercepted_snowfall)
+    expected = ((Mi⁺ + Ms⁺) - (Mi⁻ + Ms⁻)) / Δt
+
+    return total, expected
+end
+
+closure_tolerance(expected) = 1e-12 * max(1, abs(expected))
+
+@testset "Thermodynamic mass fluxes: bare ice [$timestepper]" for timestepper in (:ForwardEuler, :SplitRungeKutta3)
+    Δt = 3600
+
+    @testset "Freezing" begin
+        grid = RectilinearGrid(size=(), topology=(Flat, Flat, Flat))
+        model = SeaIceModel(grid; top_heat_flux = 100, bottom_heat_flux = 10, timestepper)
+        set!(model, h=1, ℵ=1)
+
+        total, expected = mass_flux_closure(model, Δt)
+        fluxes = model.thermodynamic_mass_fluxes
+
+        @test total ≈ expected atol=closure_tolerance(expected)
+        @test column_value(fluxes.ice) > 0
+        @test column_value(fluxes.snow) == 0
+        @test column_value(fluxes.intercepted_snowfall) == 0
+    end
+
+    @testset "Melting" begin
+        grid = RectilinearGrid(size=(), topology=(Flat, Flat, Flat))
+        model = SeaIceModel(grid; top_heat_flux = -200, bottom_heat_flux = 10, timestepper)
+        set!(model, h=1, ℵ=1)
+
+        total, expected = mass_flux_closure(model, Δt)
+        fluxes = model.thermodynamic_mass_fluxes
+
+        @test total ≈ expected atol=closure_tolerance(expected)
+        @test column_value(fluxes.ice) < 0
+        @test column_value(fluxes.snow) == 0
+        @test column_value(fluxes.intercepted_snowfall) == 0
+    end
+
+    @testset "Melt to extinction" begin
+        grid = RectilinearGrid(size=(), topology=(Flat, Flat, Flat))
+        model = SeaIceModel(grid; top_heat_flux = -1e5, bottom_heat_flux = 10, timestepper)
+        set!(model, h=0.2, ℵ=1)
+
+        total, expected = mass_flux_closure(model, Δt)
+
+        @test column_value(model.ice_thickness) == 0
+        @test column_value(model.ice_concentration) == 0
+        @test total ≈ expected atol=closure_tolerance(expected)
+    end
+end
+
+@testset "Thermodynamic mass fluxes: snow + ice [$timestepper]" for timestepper in (:ForwardEuler, :SplitRungeKutta3)
+    Δt = 3600
+    Ps = 1e-5 # kg m⁻² s⁻¹ snowfall mass flux
+
+    @testset "Freezing" begin
+        grid = RectilinearGrid(size=(), topology=(Flat, Flat, Flat))
+        model = SeaIceModel(grid;
+                            snow_thermodynamics = snow_slab_thermodynamics(grid),
+                            snowfall = Ps,
+                            top_heat_flux = 100,
+                            bottom_heat_flux = 10,
+                            timestepper)
+        set!(model, h=1, ℵ=1, hs=0.1)
+
+        total, expected = mass_flux_closure(model, Δt)
+        fluxes = model.thermodynamic_mass_fluxes
+        ℵ⁺ = column_value(model.ice_concentration)
+
+        @test total ≈ expected atol=closure_tolerance(expected)
+        @test column_value(fluxes.intercepted_snowfall) ≈ Ps * ℵ⁺ atol=1e-12 * Ps
+        @test column_value(fluxes.ice) > 0
+    end
+
+    @testset "Melting" begin
+        grid = RectilinearGrid(size=(), topology=(Flat, Flat, Flat))
+        model = SeaIceModel(grid;
+                            snow_thermodynamics = snow_slab_thermodynamics(grid),
+                            snowfall = Ps,
+                            top_heat_flux = -200,
+                            bottom_heat_flux = 10,
+                            timestepper)
+        set!(model, h=1, ℵ=1, hs=0.1)
+
+        total, expected = mass_flux_closure(model, Δt)
+        fluxes = model.thermodynamic_mass_fluxes
+        ℵ⁺ = column_value(model.ice_concentration)
+
+        @test total ≈ expected atol=closure_tolerance(expected)
+        @test column_value(fluxes.intercepted_snowfall) ≈ Ps * ℵ⁺ atol=1e-12 * Ps
+        @test column_value(fluxes.snow) < 0 # top melt removes snow faster than snowfall replenishes it
+    end
+
+    @testset "Melt to extinction" begin
+        grid = RectilinearGrid(size=(), topology=(Flat, Flat, Flat))
+        model = SeaIceModel(grid;
+                            snow_thermodynamics = snow_slab_thermodynamics(grid),
+                            snowfall = Ps,
+                            top_heat_flux = -1e5,
+                            bottom_heat_flux = 10,
+                            timestepper)
+        set!(model, h=0.2, ℵ=1, hs=0.05)
+
+        total, expected = mass_flux_closure(model, Δt)
+
+        @test column_value(model.ice_thickness) == 0
+        @test column_value(model.ice_concentration) == 0
+        @test column_value(model.snow_thickness) == 0
+        @test total ≈ expected atol=closure_tolerance(expected)
+    end
+end


### PR DESCRIPTION
To ensure freshwater conservation in a coupled system, we need to know what is the accumulated mass (of ice and snow) in the snow model just because of thermodynamics (i.e. the actual freeze - melt).
This PR introduces this concept which will be used later on in NumericalEarth to make sure all the melt (and freeze) also from the "atmospheric side" of the sea ice is felt by the ocean (at the moment it is neglected)