### PR TITLE
Include mass_fluxes in prognostic state management

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaSeaIce"
 uuid = "6ba0ff68-24e6-4315-936c-2e99227c95a4"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.5.7"
+version = "0.5.8"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/sea_ice_model.jl
+++ b/src/sea_ice_model.jl
@@ -421,7 +421,8 @@ function Oceananigans.prognostic_state(model::SIM)
             timestepper = prognostic_state(model.timestepper),
             ice_thermodynamics = prognostic_state(model.ice_thermodynamics),
             snow_thermodynamics = prognostic_state(model.snow_thermodynamics),
-            dynamics = prognostic_state(model.dynamics))
+            dynamics = prognostic_state(model.dynamics),
+            mass_fluxes = prognostic_state(model.mass_fluxes))
 end
 
 function Oceananigans.restore_prognostic_state!(model::SIM, state)
@@ -435,6 +436,7 @@ function Oceananigans.restore_prognostic_state!(model::SIM, state)
     restore_prognostic_state!(model.ice_thermodynamics, state.ice_thermodynamics)
     restore_prognostic_state!(model.snow_thermodynamics, state.snow_thermodynamics)
     restore_prognostic_state!(model.dynamics, state.dynamics)
+    restore_prognostic_state!(model.mass_fluxes, state.mass_fluxes)
     return model
 end
 

--- a/src/sea_ice_model.jl
+++ b/src/sea_ice_model.jl
@@ -436,7 +436,9 @@ function Oceananigans.restore_prognostic_state!(model::SIM, state)
     restore_prognostic_state!(model.ice_thermodynamics, state.ice_thermodynamics)
     restore_prognostic_state!(model.snow_thermodynamics, state.snow_thermodynamics)
     restore_prognostic_state!(model.dynamics, state.dynamics)
-    restore_prognostic_state!(model.mass_fluxes, state.mass_fluxes)
+    if haskey(state, :mass_fluxes) # Backwards compatible (TODO: remove)
+        restore_prognostic_state!(model.mass_fluxes, state.mass_fluxes)
+    end
     return model
 end
 


### PR DESCRIPTION
Added mass_fluxes to prognostic state restoration.
This is required to restart a coupled simulation where these mass fluxes are required to compute ice - ocean salt flux