### PR TITLE
Landfast Basal stress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,31 @@ jobs:
         env:
           TEST_GROUP: "advection"
 
+  basal_stress:
+    name: Landfast Basal Stress - Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.12'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v5
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        env:
+          TEST_GROUP: "basal_stress"
+
   energy_conservation:
     name: Energy Conservation - Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}

--- a/docs/climaseaice.bib
+++ b/docs/climaseaice.bib
@@ -67,3 +67,14 @@
   note = {J. Adv. Model. Earth Sy., submitted in April 2026},
   doi = {10.22541/essoar.15002225/v1}
 }
+
+@article{Lemieux2015,
+  author = {Lemieux, Jean-François and Tremblay, L. Bruno and Dupont, Frédéric and Plante, Mathieu and Smith, Gregory C. and Dumont, Dany},
+  title = {A basal stress parameterization for modeling landfast ice},
+  journal = {Journal of Geophysical Research: Oceans},
+  year = {2015},
+  volume = {120},
+  number = {4},
+  pages = {3157--3173},
+  doi = {10.1002/2014JC010678}
+}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,6 +19,7 @@ example_scripts = [
     "freezing_of_a_lake.jl",
     "ice_advected_by_anticyclone.jl",
     "ice_advected_on_coastline.jl",
+    "landfast_sea_ice.jl",
     "arctic_basin_seasonal_cycle.jl"
 ]
 
@@ -33,6 +34,7 @@ example_pages = [
     "Freezing of a Lake" => "literated/freezing_of_a_lake.md",
     "Ice advected by anticyclone" => "literated/ice_advected_by_anticyclone.md",
     "Ice advected on coastline" => "literated/ice_advected_on_coastline.md",
+    "Landfast sea ice" => "literated/landfast_sea_ice.md",
     "Arctic basin seasonal cycle" => "literated/arctic_basin_seasonal_cycle.md"
 ]
 

--- a/examples/landfast_sea_ice.jl
+++ b/examples/landfast_sea_ice.jl
@@ -1,0 +1,182 @@
+# # Landfast sea ice
+#
+# This example shows sea ice grounding on a shallow shelf. Wind blows along a coast whose water
+# deepens offshore, and where the ice keels are thick enough to reach the sea floor the bed arrests
+# them: a stationary landfast belt forms against the coast while the pack streams freely offshore.
+# Running the same configuration with and without [`LandfastBasalStress`](@ref) isolates the effect.
+# This example demonstrates how to:
+#
+#   * give a sea-ice model a bathymetry it can ground on,
+#   * switch on the Lemieux et al. (2015) basal stress,
+#   * visualize the landfast belt it produces.
+#
+# ## Install dependencies
+#
+# ```julia
+# using Pkg
+# pkg"add Oceananigans, ClimaSeaIce, CairoMakie"
+# ```
+
+using ClimaSeaIce
+using Oceananigans
+using Oceananigans.Units
+using Printf
+using CairoMakie
+
+# ## The physical domain
+#
+# The domain is a coastal strip, periodic along the coast and bounded across it. Unlike a pure
+# sea-ice problem, the grid needs a vertical extent: the basal stress is driven by the water depth,
+# so the model has to be told where the sea floor is.
+
+Lx, Ly = 200kilometers, 100kilometers
+Nx, Ny, Nz = 128, 64, 30
+
+coastal_depth = 2      # m, at the coast
+offshore_depth = 60    # m, at the open boundary
+
+# The vertical grid must resolve the shelf. With cells thicker than the coastal depth the whole top
+# cell would be immersed and the column depth would collapse to zero.
+
+underlying_grid = RectilinearGrid(size = (Nx, Ny, Nz),
+                                     x = (0, Lx),
+                                     y = (0, Ly),
+                                     z = (-offshore_depth, 0),
+                                  halo = (4, 4, 4),
+                              topology = (Periodic, Bounded, Bounded))
+
+@inline sea_floor(x, y) = - (coastal_depth + (offshore_depth - coastal_depth) * y / Ly)
+
+grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBottom(sea_floor))
+
+# ## Where the ice grounds
+#
+# Keels ground where the ice is thicker than the critical thickness ``hᶜ = H ℵ / k₁``. With ``k₁ = 8``
+# and three metres of fully concentrated ice, that is everywhere shallower than 24 m:
+
+ice_thickness = 3.0
+critical_thickness_parameter = 8
+
+grounding_depth = critical_thickness_parameter * ice_thickness
+grounding_line = Ly * (grounding_depth - coastal_depth) / (offshore_depth - coastal_depth)
+
+@info @sprintf("Ice grounds in water shallower than %.0f m, i.e. within %.0f km of the coast", grounding_depth, grounding_line / 1e3)
+
+# ## Atmospheric and oceanic forcing
+#
+# The wind blows along the coast with a component pushing the ice onshore, so the pack is driven
+# against the shelf:
+
+𝓋ₐ = 15.0    # m s⁻¹
+Cᴰ = 1.2e-3  # atmosphere-sea ice drag coefficient
+ρₐ = 1.3     # kg m⁻³
+
+τₐ = ρₐ * Cᴰ * 𝓋ₐ^2
+
+τᵤ = XFaceField(grid)
+τᵥ = YFaceField(grid)
+set!(τᵤ, - τₐ)          # along the coast
+set!(τᵥ, - 0.3 * τₐ)    # and towards it
+Oceananigans.BoundaryConditions.fill_halo_regions!(τᵤ)
+Oceananigans.BoundaryConditions.fill_halo_regions!(τᵥ)
+
+# The ocean is at rest, so its stress opposes any ice motion:
+
+τₒ = SemiImplicitStress()
+
+# ## Running the two configurations
+#
+# The only difference between the runs is whether the sea floor is allowed to grip the ice.
+
+function run_landfast_simulation(basal_stress; stop_time = 2days, Δt = 10minutes)
+    dynamics = SeaIceMomentumEquation(grid;
+                                      top_momentum_stress = (u=τᵤ, v=τᵥ),
+                                      bottom_momentum_stress = τₒ,
+                                      rheology = ElastoViscoPlasticRheology(),
+                                      basal_stress,
+                                      solver = SplitExplicitSolver(grid; substeps=150))
+
+    model = SeaIceModel(grid; dynamics,
+                        advection = WENO(order=7),
+                        ice_thermodynamics = nothing)
+
+    set!(model, h = ice_thickness)
+    set!(model, ℵ = 1)
+
+    simulation = Simulation(model; Δt, stop_time)
+
+    speed = []
+    thickness = []
+
+    # `u` and `v` live on different faces, so let Oceananigans interpolate the speed to cell centres
+    # rather than broadcasting arrays of different sizes together.
+    s = Field(sqrt(model.velocities.u^2 + model.velocities.v^2))
+
+    function accumulate!(sim)
+        compute!(s)
+        push!(speed, deepcopy(Array(interior(s))[:, :, 1]))
+        push!(thickness, deepcopy(Array(interior(sim.model.ice_thickness))[:, :, 1]))
+    end
+
+    simulation.callbacks[:save] = Callback(accumulate!, IterationInterval(6))
+
+    run!(simulation)
+
+    return speed, thickness
+end
+
+drifting_speed, drifting_thickness = run_landfast_simulation(nothing)
+landfast_speed, landfast_thickness = run_landfast_simulation(LandfastBasalStress())
+
+# ## Visualizing the landfast belt
+
+x = xnodes(grid, Center()) ./ 1e3
+y = ynodes(grid, Center()) ./ 1e3
+
+Nt = length(landfast_speed)
+iter = Observable(Nt)
+
+sᵈ = @lift(100 .* drifting_speed[$iter])
+sˡ = @lift(100 .* landfast_speed[$iter])
+hˡ = @lift(landfast_thickness[$iter])
+
+fig = Figure(size = (1100, 640))
+
+ax = Axis(fig[1, 1], title = "Ice speed without basal stress (cm/s)",
+          xlabel = "x (km)", ylabel = "y (km)")
+heatmap!(ax, x, y, sᵈ, colormap = :speed, colorrange = (0, 30))
+hlines!(ax, grounding_line / 1e3, color = :white, linestyle = :dash, linewidth = 2)
+
+ax = Axis(fig[1, 2], title = "Ice speed with basal stress (cm/s)",
+          xlabel = "x (km)", ylabel = "y (km)")
+hm = heatmap!(ax, x, y, sˡ, colormap = :speed, colorrange = (0, 30))
+hlines!(ax, grounding_line / 1e3, color = :white, linestyle = :dash, linewidth = 2)
+Colorbar(fig[1, 3], hm)
+
+# The cross-shore profile makes the arrest unambiguous: the belt inshore of the grounding line stops
+# while the pack offshore of it keeps drifting.
+
+ax = Axis(fig[2, 1:3], title = "Cross-shore profile of ice speed",
+          xlabel = "Distance from the coast (km)", ylabel = "Speed (cm/s)")
+lines!(ax, y, @lift(vec(sum($sᵈ, dims=1)) ./ Nx), linewidth = 3, label = "no basal stress")
+lines!(ax, y, @lift(vec(sum($sˡ, dims=1)) ./ Nx), linewidth = 3, label = "basal stress")
+vlines!(ax, grounding_line / 1e3, color = :black, linestyle = :dash, label = "grounding line")
+axislegend(ax, position = :rb)
+ylims!(ax, 0, 30)
+
+CairoMakie.record(fig, "landfast_sea_ice.mp4", 1:Nt, framerate = 8) do i
+    iter[] = i
+end
+nothing #hide
+
+# ![](landfast_sea_ice.mp4)
+#
+# Without the basal stress the whole pack drifts at a uniform 25 cm/s, and the coast is simply a wall
+# the ice piles against. With it, the ice inshore of the grounding line is held by its keels and stops
+# dead. The step in the cross-shore profile is the landfast edge, and it falls where the bathymetry
+# crosses ``H = k₁ h / ℵ`` — a line fixed by the parameters, not fitted to the result.
+#
+# The pack offshore of the belt is not merely left alone: it slows from 25 to about 11 cm/s. Sea ice
+# is a continuum, so the grounded belt buttresses the ice beyond it through the internal stress. That
+# indirect effect reaches much further than the grounding line itself, which is why a landfast
+# parameterization changes an ice pack well outside the shallow water it acts in.

--- a/examples/landfast_sea_ice.jl
+++ b/examples/landfast_sea_ice.jl
@@ -67,11 +67,11 @@ grounding_line = Ly * (grounding_depth - coastal_depth) / (offshore_depth - coas
 # The wind blows along the coast with a component pushing the ice onshore, so the pack is driven
 # against the shelf:
 
-𝓋ₐ = 15.0    # m s⁻¹
+uₐ = 15.0    # m s⁻¹
 Cᴰ = 1.2e-3  # atmosphere-sea ice drag coefficient
 ρₐ = 1.3     # kg m⁻³
 
-τₐ = ρₐ * Cᴰ * 𝓋ₐ^2
+τₐ = ρₐ * Cᴰ * uₐ^2
 
 τᵤ = XFaceField(grid)
 τᵥ = YFaceField(grid)
@@ -108,8 +108,6 @@ function run_landfast_simulation(basal_stress; stop_time = 2days, Δt = 10minute
     speed = []
     thickness = []
 
-    # `u` and `v` live on different faces, so let Oceananigans interpolate the speed to cell centres
-    # rather than broadcasting arrays of different sizes together.
     s = Field(sqrt(model.velocities.u^2 + model.velocities.v^2))
 
     function accumulate!(sim)

--- a/src/ClimaSeaIce.jl
+++ b/src/ClimaSeaIce.jl
@@ -22,6 +22,7 @@ export SeaIceModel,
        SplitExplicitSolver,
        SemiImplicitStress,
        StressBalanceFreeDrift,
+       LandfastBasalStress,
        ViscousRheology,
        ElastoViscoPlasticRheology
 

--- a/src/SeaIceDynamics/SeaIceDynamics.jl
+++ b/src/SeaIceDynamics/SeaIceDynamics.jl
@@ -2,7 +2,8 @@ module SeaIceDynamics
 
 # The only functions provided by the module
 export compute_momentum_tendencies!, time_step_momentum!
-export SeaIceMomentumEquation, ExplicitSolver, SplitExplicitSolver, SemiImplicitStress, StressBalanceFreeDrift
+export SeaIceMomentumEquation, ExplicitSolver, SplitExplicitSolver, SemiImplicitStress, StressBalanceFreeDrift,
+       LandfastBasalStress
 
 using Adapt: Adapt
 using KernelAbstractions: @kernel, @index
@@ -41,6 +42,7 @@ time_step_momentum!(model, dynamics, Δt) = nothing
 compute_momentum_tendencies!(model, dynamics, Δt) = nothing
 
 include("sea_ice_external_stress.jl")
+include("landfast_basal_stress.jl")
 include("stress_balance_free_drift.jl")
 include("sea_ice_momentum_equations.jl")
 include("momentum_tendencies_kernel_functions.jl")

--- a/src/SeaIceDynamics/explicit_momentum_equations.jl
+++ b/src/SeaIceDynamics/explicit_momentum_equations.jl
@@ -27,18 +27,19 @@ function time_step_momentum!(model, ::ExplicitMomentumEquation, Δt)
 
     top_stress = dynamics.external_momentum_stresses.top
     bottom_stress = dynamics.external_momentum_stresses.bottom
+    basal_stress = dynamics.basal_stress
 
-    launch!(arch, grid, :xy, _step_u_velocity!, u, u⁻, grid, Gⁿ, Δt, top_stress, bottom_stress, free_drift, minimum_mass, minimum_concentration, clock, model_fields)
+    launch!(arch, grid, :xy, _step_u_velocity!, u, u⁻, grid, Gⁿ, Δt, top_stress, bottom_stress, basal_stress, free_drift, minimum_mass, minimum_concentration, clock, model_fields)
     fill_halo_regions!(u)
 
-    launch!(arch, grid, :xy, _step_v_velocity!, v, v⁻, grid, Gⁿ, Δt, top_stress, bottom_stress, free_drift, minimum_mass, minimum_concentration, clock, model_fields)
+    launch!(arch, grid, :xy, _step_v_velocity!, v, v⁻, grid, Gⁿ, Δt, top_stress, bottom_stress, basal_stress, free_drift, minimum_mass, minimum_concentration, clock, model_fields)
     fill_halo_regions!(v)
 
     return nothing
 end
 
 @kernel function _step_u_velocity!(u, u⁻, grid, Gⁿ, Δt,
-                                   top_stress, bottom_stress,
+                                   top_stress, bottom_stress, basal_stress,
                                    free_drift, minimum_mass, minimum_concentration, clock, fields)
 
     i, j = @index(Global, NTuple)
@@ -47,7 +48,8 @@ end
     mᶠᶜ  = ℑxᶠᵃᵃ(i, j, kᴺ, grid, ice_mass, fields.h, fields.ℵ, fields.ρ)
 
     τuᵢ = ( implicit_τx_coefficient(i, j, kᴺ, grid, bottom_stress, clock, fields)
-          - implicit_τx_coefficient(i, j, kᴺ, grid, top_stress,    clock, fields)) / mᶠᶜ * ℵᶠᶜ
+          - implicit_τx_coefficient(i, j, kᴺ, grid, top_stress,    clock, fields)) / mᶠᶜ * ℵᶠᶜ +
+          basal_τx_coefficient(i, j, kᴺ, grid, basal_stress, fields) / mᶠᶜ
 
     @inbounds begin
         uᴰ = (u⁻[i, j, 1] + Δt * Gⁿ.u[i, j, 1]) / (1 + Δt * τuᵢ)
@@ -60,7 +62,7 @@ end
 end
 
 @kernel function _step_v_velocity!(v, v⁻, grid, Gⁿ, Δt,
-                                   top_stress, bottom_stress,
+                                   top_stress, bottom_stress, basal_stress,
                                    free_drift, minimum_mass, minimum_concentration, clock, fields)
 
     i, j = @index(Global, NTuple)
@@ -69,7 +71,8 @@ end
     mᶜᶠ  = ℑyᵃᶠᵃ(i, j, kᴺ, grid, ice_mass, fields.h, fields.ℵ, fields.ρ)
 
     τvᵢ = ( implicit_τy_coefficient(i, j, kᴺ, grid, bottom_stress, clock, fields)
-          - implicit_τy_coefficient(i, j, kᴺ, grid, top_stress,    clock, fields)) / mᶜᶠ * ℵᶜᶠ
+          - implicit_τy_coefficient(i, j, kᴺ, grid, top_stress,    clock, fields)) / mᶜᶠ * ℵᶜᶠ +
+          basal_τy_coefficient(i, j, kᴺ, grid, basal_stress, fields) / mᶜᶠ
 
     @inbounds begin
         vᴰ = (v⁻[i, j, 1] + Δt * Gⁿ.v[i, j, 1]) / (1 + Δt * τvᵢ)

--- a/src/SeaIceDynamics/explicit_momentum_equations.jl
+++ b/src/SeaIceDynamics/explicit_momentum_equations.jl
@@ -48,7 +48,7 @@ end
     mᶠᶜ  = ℑxᶠᵃᵃ(i, j, kᴺ, grid, ice_mass, fields.h, fields.ℵ, fields.ρ)
 
     τuᵢ = ( implicit_τx_coefficient(i, j, kᴺ, grid, bottom_stress, clock, fields) / mᶠᶜ * ℵᶠᶜ
-          - implicit_τx_coefficient(i, j, kᴺ, grid, top_stress,    clock, fields) / mᶠᶜ * ℵᶠᶜ 
+          - implicit_τx_coefficient(i, j, kᴺ, grid, top_stress,    clock, fields) / mᶠᶜ * ℵᶠᶜ
           + basal_τx_coefficient(i, j, kᴺ, grid, basal_stress, fields) / mᶠᶜ)
 
     @inbounds begin

--- a/src/SeaIceDynamics/explicit_momentum_equations.jl
+++ b/src/SeaIceDynamics/explicit_momentum_equations.jl
@@ -47,9 +47,9 @@ end
     ℵᶠᶜ  = ℑxᶠᵃᵃ(i, j, kᴺ, grid, fields.ℵ)
     mᶠᶜ  = ℑxᶠᵃᵃ(i, j, kᴺ, grid, ice_mass, fields.h, fields.ℵ, fields.ρ)
 
-    τuᵢ = ( implicit_τx_coefficient(i, j, kᴺ, grid, bottom_stress, clock, fields)
-          - implicit_τx_coefficient(i, j, kᴺ, grid, top_stress,    clock, fields)) / mᶠᶜ * ℵᶠᶜ
-          + basal_τx_coefficient(i, j, kᴺ, grid, basal_stress, fields) / mᶠᶜ
+    τuᵢ = ( implicit_τx_coefficient(i, j, kᴺ, grid, bottom_stress, clock, fields) / mᶠᶜ * ℵᶠᶜ
+          - implicit_τx_coefficient(i, j, kᴺ, grid, top_stress,    clock, fields) / mᶠᶜ * ℵᶠᶜ 
+          + basal_τx_coefficient(i, j, kᴺ, grid, basal_stress, fields) / mᶠᶜ)
 
     @inbounds begin
         uᴰ = (u⁻[i, j, 1] + Δt * Gⁿ.u[i, j, 1]) / (1 + Δt * τuᵢ)
@@ -70,9 +70,9 @@ end
     ℵᶜᶠ  = ℑyᵃᶠᵃ(i, j, kᴺ, grid, fields.ℵ)
     mᶜᶠ  = ℑyᵃᶠᵃ(i, j, kᴺ, grid, ice_mass, fields.h, fields.ℵ, fields.ρ)
 
-    τvᵢ = ( implicit_τy_coefficient(i, j, kᴺ, grid, bottom_stress, clock, fields)
-          - implicit_τy_coefficient(i, j, kᴺ, grid, top_stress,    clock, fields)) / mᶜᶠ * ℵᶜᶠ
-          + basal_τy_coefficient(i, j, kᴺ, grid, basal_stress, fields) / mᶜᶠ
+    τvᵢ = ( implicit_τy_coefficient(i, j, kᴺ, grid, bottom_stress, clock, fields) / mᶜᶠ * ℵᶜᶠ
+          - implicit_τy_coefficient(i, j, kᴺ, grid, top_stress,    clock, fields) / mᶜᶠ * ℵᶜᶠ
+          + basal_τy_coefficient(i, j, kᴺ, grid, basal_stress, fields) / mᶜᶠ)
 
     @inbounds begin
         vᴰ = (v⁻[i, j, 1] + Δt * Gⁿ.v[i, j, 1]) / (1 + Δt * τvᵢ)

--- a/src/SeaIceDynamics/explicit_momentum_equations.jl
+++ b/src/SeaIceDynamics/explicit_momentum_equations.jl
@@ -48,8 +48,8 @@ end
     mᶠᶜ  = ℑxᶠᵃᵃ(i, j, kᴺ, grid, ice_mass, fields.h, fields.ℵ, fields.ρ)
 
     τuᵢ = ( implicit_τx_coefficient(i, j, kᴺ, grid, bottom_stress, clock, fields)
-          - implicit_τx_coefficient(i, j, kᴺ, grid, top_stress,    clock, fields)) / mᶠᶜ * ℵᶠᶜ +
-          basal_τx_coefficient(i, j, kᴺ, grid, basal_stress, fields) / mᶠᶜ
+          - implicit_τx_coefficient(i, j, kᴺ, grid, top_stress,    clock, fields)) / mᶠᶜ * ℵᶠᶜ
+          + basal_τx_coefficient(i, j, kᴺ, grid, basal_stress, fields) / mᶠᶜ
 
     @inbounds begin
         uᴰ = (u⁻[i, j, 1] + Δt * Gⁿ.u[i, j, 1]) / (1 + Δt * τuᵢ)
@@ -71,8 +71,8 @@ end
     mᶜᶠ  = ℑyᵃᶠᵃ(i, j, kᴺ, grid, ice_mass, fields.h, fields.ℵ, fields.ρ)
 
     τvᵢ = ( implicit_τy_coefficient(i, j, kᴺ, grid, bottom_stress, clock, fields)
-          - implicit_τy_coefficient(i, j, kᴺ, grid, top_stress,    clock, fields)) / mᶜᶠ * ℵᶜᶠ +
-          basal_τy_coefficient(i, j, kᴺ, grid, basal_stress, fields) / mᶜᶠ
+          - implicit_τy_coefficient(i, j, kᴺ, grid, top_stress,    clock, fields)) / mᶜᶠ * ℵᶜᶠ
+          + basal_τy_coefficient(i, j, kᴺ, grid, basal_stress, fields) / mᶜᶠ
 
     @inbounds begin
         vᴰ = (v⁻[i, j, 1] + Δt * Gⁿ.v[i, j, 1]) / (1 + Δt * τvᵢ)

--- a/src/SeaIceDynamics/landfast_basal_stress.jl
+++ b/src/SeaIceDynamics/landfast_basal_stress.jl
@@ -1,0 +1,151 @@
+using Oceananigans.Grids: AbstractGrid, znode
+using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, static_column_depthᶜᶜᵃ
+using Oceananigans.BoundaryConditions: fill_halo_regions!
+
+"""
+    LandfastBasalStress{FT, W}
+
+Stress exerted by the sea floor on grounded sea-ice keels, following
+[Lemieux et al. (2015)](@cite Lemieux2015).
+
+Where the ice is thick enough that its keels reach the sea floor, the bed arrests the ice, producing
+the landfast belt observed along shallow shelves and through narrow channels. The stress is
+
+```math
+τᵇ = k₂ \\max(0, h - hᶜ) \\exp[-C (1 - ℵ)] \\frac{𝐮}{|𝐮| + u₀}, \\qquad hᶜ = \\frac{H ℵ}{k₁}
+```
+
+where ``H`` is the still-water column depth, ``h`` the ice thickness, ``ℵ`` the ice concentration, and
+``u₀`` a small velocity that keeps the stress finite as ``𝐮 → 0``. Note that ``τᵇ`` saturates at
+``k₂ (h - hᶜ)`` and vanishes with ``𝐮``: the bed can arrest ice, never accelerate it. The stress acts
+only where ``H`` is smaller than `maximum_water_depth`.
+
+Because ``τᵇ`` is stiff at small velocity it is treated implicitly by the momentum solver, alongside
+the ice-ocean drag. It is carried by the sea floor rather than by the water column, so it is held
+separately from `external_momentum_stresses` and never appears in the stress passed to an ocean.
+
+Pass it to [`SeaIceMomentumEquation`](@ref) as `basal_stress`.
+"""
+struct LandfastBasalStress{FT, W}
+    critical_thickness_parameter :: FT
+    stress_parameter :: FT
+    concentration_hardening :: FT
+    minimum_speed :: FT
+    maximum_water_depth :: FT
+    water_depth :: W
+end
+
+"""
+    LandfastBasalStress(FT = Oceananigans.defaults.FloatType;
+                        critical_thickness_parameter = 8,
+                        stress_parameter = 15,
+                        concentration_hardening = 20,
+                        minimum_speed = 5e-5,
+                        maximum_water_depth = 30)
+
+Construct a `LandfastBasalStress`. The returned object is a skeleton whose `water_depth` is `nothing`;
+the depth field is built by `SeaIceMomentumEquation` once the grid is known.
+
+Keyword Arguments
+=================
+
+- `critical_thickness_parameter`: ``k₁``, setting the keel thickness that grounds in a column of
+                                  depth ``H``. Default: `8`.
+- `stress_parameter`: ``k₂`` (N m⁻³). Default: `15`.
+- `concentration_hardening`: ``C``, suppressing the stress in unconsolidated ice. Default: `20`.
+- `minimum_speed`: ``u₀`` (m s⁻¹), regularizing the stress at vanishing velocity. Default: `5e-5`.
+- `maximum_water_depth`: depth (m) beyond which no grounding is possible. Default: `30`.
+"""
+function LandfastBasalStress(FT::DataType = Oceananigans.defaults.FloatType;
+                             critical_thickness_parameter = 8,
+                             stress_parameter = 15,
+                             concentration_hardening = 20,
+                             minimum_speed = 5e-5,
+                             maximum_water_depth = 30)
+
+    return LandfastBasalStress(convert(FT, critical_thickness_parameter),
+                               convert(FT, stress_parameter),
+                               convert(FT, concentration_hardening),
+                               convert(FT, minimum_speed),
+                               convert(FT, maximum_water_depth),
+                               nothing)
+end
+
+Base.summary(::LandfastBasalStress{FT}) where FT = "LandfastBasalStress{$FT}"
+
+function Base.show(io::IO, b::LandfastBasalStress)
+    print(io, summary(b), '\n')
+    print(io, "├── critical_thickness_parameter: ", b.critical_thickness_parameter, '\n')
+    print(io, "├── stress_parameter: ", b.stress_parameter, '\n')
+    print(io, "├── concentration_hardening: ", b.concentration_hardening, '\n')
+    print(io, "├── minimum_speed: ", b.minimum_speed, '\n')
+    print(io, "└── maximum_water_depth: ", b.maximum_water_depth)
+end
+
+Adapt.adapt_structure(to, b::LandfastBasalStress) =
+    LandfastBasalStress(b.critical_thickness_parameter,
+                        b.stress_parameter,
+                        b.concentration_hardening,
+                        b.minimum_speed,
+                        b.maximum_water_depth,
+                        Adapt.adapt(to, b.water_depth))
+
+# Without bathymetry every column is as deep as the domain, and nothing grounds.
+@inline column_depth(i, j, grid) = @inbounds - znode(i, j, 1, grid, Center(), Center(), Face())
+@inline column_depth(i, j, ibg::ImmersedBoundaryGrid) = static_column_depthᶜᶜᵃ(i, j, ibg)
+
+@kernel function _compute_water_depth!(H, grid)
+    i, j = @index(Global, NTuple)
+    @inbounds H[i, j, 1] = column_depth(i, j, grid)
+end
+
+materialize_basal_stress(::Nothing, grid) = nothing
+
+function materialize_basal_stress(b::LandfastBasalStress, grid::AbstractGrid)
+    H = Field{Center, Center, Nothing}(grid)
+    launch!(architecture(grid), grid, :xy, _compute_water_depth!, H, grid)
+    fill_halo_regions!(H)
+
+    return LandfastBasalStress(b.critical_thickness_parameter,
+                               b.stress_parameter,
+                               b.concentration_hardening,
+                               b.minimum_speed,
+                               b.maximum_water_depth,
+                               H)
+end
+
+# Grounded keel thickness in excess of what the column can accommodate, hardened by concentration.
+# The magnitude is a cell-centred property, so it is formed at centres and only then interpolated:
+# averaging h, ℵ and H to a velocity point first halves both the keel and the critical thickness
+# against a dry neighbour, and the criterion silently cancels itself along a coastline.
+@inline function basal_stress_magnitude(i, j, k, grid, b, fields)
+    h = @inbounds fields.h[i, j, 1]
+    ℵ = @inbounds fields.ℵ[i, j, 1]
+    H = @inbounds b.water_depth[i, j, 1]
+    δh = max(0, h - H * ℵ / b.critical_thickness_parameter)
+    kᵇ = b.stress_parameter * δh * exp(- b.concentration_hardening * (1 - ℵ))
+    return ifelse(H < b.maximum_water_depth, kᵇ, zero(grid))
+end
+
+"""
+    basal_τx_coefficient(i, j, k, grid, basal_stress, fields)
+    basal_τy_coefficient(i, j, k, grid, basal_stress, fields)
+
+Return the coefficient ``τᵇ / u`` of the basal stress, for implicit treatment by the momentum solver.
+"""
+@inline function basal_τx_coefficient(i, j, k, grid, b::LandfastBasalStress, fields)
+    kᵇ = ℑxᶠᵃᵃ(i, j, 1, grid, basal_stress_magnitude, b, fields)
+    u = @inbounds fields.u[i, j, k]
+    v = ℑxyᶠᶜᵃ(i, j, k, grid, fields.v)
+    return kᵇ / (sqrt(u^2 + v^2) + b.minimum_speed)
+end
+
+@inline function basal_τy_coefficient(i, j, k, grid, b::LandfastBasalStress, fields)
+    kᵇ = ℑyᵃᶠᵃ(i, j, 1, grid, basal_stress_magnitude, b, fields)
+    u = ℑxyᶜᶠᵃ(i, j, k, grid, fields.u)
+    v = @inbounds fields.v[i, j, k]
+    return kᵇ / (sqrt(u^2 + v^2) + b.minimum_speed)
+end
+
+@inline basal_τx_coefficient(i, j, k, grid, ::Nothing, fields) = zero(grid)
+@inline basal_τy_coefficient(i, j, k, grid, ::Nothing, fields) = zero(grid)

--- a/src/SeaIceDynamics/landfast_basal_stress.jl
+++ b/src/SeaIceDynamics/landfast_basal_stress.jl
@@ -1,6 +1,4 @@
-using Oceananigans.Grids: AbstractGrid, znode
-using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, static_column_depthᶜᶜᵃ
-using Oceananigans.BoundaryConditions: fill_halo_regions!
+using Oceananigans.Grids: static_column_depthᶜᶜᵃ
 
 """
     LandfastBasalStress{FT}
@@ -42,8 +40,8 @@ end
                         minimum_speed = 5e-5,
                         maximum_water_depth = 30)
 
-Construct a `LandfastBasalStress`. The returned object is a skeleton whose `water_depth` is `nothing`;
-the depth field is built by `SeaIceMomentumEquation` once the grid is known.
+Construct a `LandfastBasalStress`. The still-water column depth ``H`` is read from the grid, so the
+same object may be passed to any grid.
 
 Keyword Arguments
 =================

--- a/src/SeaIceDynamics/landfast_basal_stress.jl
+++ b/src/SeaIceDynamics/landfast_basal_stress.jl
@@ -3,7 +3,7 @@ using Oceananigans.ImmersedBoundaries: ImmersedBoundaryGrid, static_column_depth
 using Oceananigans.BoundaryConditions: fill_halo_regions!
 
 """
-    LandfastBasalStress{FT, W}
+    LandfastBasalStress{FT}
 
 Stress exerted by the sea floor on grounded sea-ice keels, following
 [Lemieux et al. (2015)](@cite Lemieux2015).
@@ -26,13 +26,12 @@ separately from `external_momentum_stresses` and never appears in the stress pas
 
 Pass it to [`SeaIceMomentumEquation`](@ref) as `basal_stress`.
 """
-struct LandfastBasalStress{FT, W}
+struct LandfastBasalStress{FT}
     critical_thickness_parameter :: FT
     stress_parameter :: FT
     concentration_hardening :: FT
     minimum_speed :: FT
     maximum_water_depth :: FT
-    water_depth :: W
 end
 
 """
@@ -67,8 +66,7 @@ function LandfastBasalStress(FT::DataType = Oceananigans.defaults.FloatType;
                                convert(FT, stress_parameter),
                                convert(FT, concentration_hardening),
                                convert(FT, minimum_speed),
-                               convert(FT, maximum_water_depth),
-                               nothing)
+                               convert(FT, maximum_water_depth))
 end
 
 Base.summary(::LandfastBasalStress{FT}) where FT = "LandfastBasalStress{$FT}"
@@ -87,41 +85,15 @@ Adapt.adapt_structure(to, b::LandfastBasalStress) =
                         b.stress_parameter,
                         b.concentration_hardening,
                         b.minimum_speed,
-                        b.maximum_water_depth,
-                        Adapt.adapt(to, b.water_depth))
+                        b.maximum_water_depth)
 
-# Without bathymetry every column is as deep as the domain, and nothing grounds.
-@inline column_depth(i, j, grid) = @inbounds - znode(i, j, 1, grid, Center(), Center(), Face())
-@inline column_depth(i, j, ibg::ImmersedBoundaryGrid) = static_column_depthᶜᶜᵃ(i, j, ibg)
-
-@kernel function _compute_water_depth!(H, grid)
-    i, j = @index(Global, NTuple)
-    @inbounds H[i, j, 1] = column_depth(i, j, grid)
-end
-
-materialize_basal_stress(::Nothing, grid) = nothing
-
-function materialize_basal_stress(b::LandfastBasalStress, grid::AbstractGrid)
-    H = Field{Center, Center, Nothing}(grid)
-    launch!(architecture(grid), grid, :xy, _compute_water_depth!, H, grid)
-    fill_halo_regions!(H)
-
-    return LandfastBasalStress(b.critical_thickness_parameter,
-                               b.stress_parameter,
-                               b.concentration_hardening,
-                               b.minimum_speed,
-                               b.maximum_water_depth,
-                               H)
-end
+materialize_basal_stress(stress, grid) = stress
 
 # Grounded keel thickness in excess of what the column can accommodate, hardened by concentration.
-# The magnitude is a cell-centred property, so it is formed at centres and only then interpolated:
-# averaging h, ℵ and H to a velocity point first halves both the keel and the critical thickness
-# against a dry neighbour, and the criterion silently cancels itself along a coastline.
 @inline function basal_stress_magnitude(i, j, k, grid, b, fields)
     h = @inbounds fields.h[i, j, 1]
     ℵ = @inbounds fields.ℵ[i, j, 1]
-    H = @inbounds b.water_depth[i, j, 1]
+    H = static_column_depthᶜᶜᵃ(i, j, grid)
     δh = max(0, h - H * ℵ / b.critical_thickness_parameter)
     kᵇ = b.stress_parameter * δh * exp(- b.concentration_hardening * (1 - ℵ))
     return ifelse(H < b.maximum_water_depth, kᵇ, zero(grid))
@@ -135,15 +107,15 @@ Return the coefficient ``τᵇ / u`` of the basal stress, for implicit treatment
 """
 @inline function basal_τx_coefficient(i, j, k, grid, b::LandfastBasalStress, fields)
     kᵇ = ℑxᶠᵃᵃ(i, j, 1, grid, basal_stress_magnitude, b, fields)
-    u = @inbounds fields.u[i, j, k]
-    v = ℑxyᶠᶜᵃ(i, j, k, grid, fields.v)
+    u  = @inbounds fields.u[i, j, k]
+    v  = ℑxyᶠᶜᵃ(i, j, k, grid, fields.v)
     return kᵇ / (sqrt(u^2 + v^2) + b.minimum_speed)
 end
 
 @inline function basal_τy_coefficient(i, j, k, grid, b::LandfastBasalStress, fields)
     kᵇ = ℑyᵃᶠᵃ(i, j, 1, grid, basal_stress_magnitude, b, fields)
-    u = ℑxyᶜᶠᵃ(i, j, k, grid, fields.u)
-    v = @inbounds fields.v[i, j, k]
+    u  = ℑxyᶜᶠᵃ(i, j, k, grid, fields.u)
+    v  = @inbounds fields.v[i, j, k]
     return kᵇ / (sqrt(u^2 + v^2) + b.minimum_speed)
 end
 

--- a/src/SeaIceDynamics/landfast_basal_stress.jl
+++ b/src/SeaIceDynamics/landfast_basal_stress.jl
@@ -6,23 +6,16 @@ using Oceananigans.Grids: static_column_depthᶜᶜᵃ
 Stress exerted by the sea floor on grounded sea-ice keels, following
 [Lemieux et al. (2015)](@cite Lemieux2015).
 
-Where the ice is thick enough that its keels reach the sea floor, the bed arrests the ice, producing
-the landfast belt observed along shallow shelves and through narrow channels. The stress is
+Where the ice keels reach the sea floor the bed arrests the ice, producing the landfast belt observed
+along shallow shelves and through narrow channels. The stress is
 
 ```math
 τᵇ = k₂ \\max(0, h - hᶜ) \\exp[-C (1 - ℵ)] \\frac{𝐮}{|𝐮| + u₀}, \\qquad hᶜ = \\frac{H ℵ}{k₁}
 ```
 
 where ``H`` is the still-water column depth, ``h`` the ice thickness, ``ℵ`` the ice concentration, and
-``u₀`` a small velocity that keeps the stress finite as ``𝐮 → 0``. Note that ``τᵇ`` saturates at
-``k₂ (h - hᶜ)`` and vanishes with ``𝐮``: the bed can arrest ice, never accelerate it. The stress acts
-only where ``H`` is smaller than `maximum_water_depth`.
-
-Because ``τᵇ`` is stiff at small velocity it is treated implicitly by the momentum solver, alongside
-the ice-ocean drag. It is carried by the sea floor rather than by the water column, so it is held
-separately from `external_momentum_stresses` and never appears in the stress passed to an ocean.
-
-Pass it to [`SeaIceMomentumEquation`](@ref) as `basal_stress`.
+``u₀`` a small velocity that keeps the stress finite as ``𝐮 → 0``. It acts only where ``H`` is smaller
+than `maximum_water_depth`, and is treated implicitly by the momentum solver.
 """
 struct LandfastBasalStress{FT}
     critical_thickness_parameter :: FT
@@ -40,8 +33,7 @@ end
                         minimum_speed = 5e-5,
                         maximum_water_depth = 30)
 
-Construct a `LandfastBasalStress`. The still-water column depth ``H`` is read from the grid, so the
-same object may be passed to any grid.
+Construct a `LandfastBasalStress`. The still-water column depth ``H`` is read from the grid.
 
 Keyword Arguments
 =================
@@ -97,12 +89,7 @@ materialize_basal_stress(stress, grid) = stress
     return ifelse(H < b.maximum_water_depth, kᵇ, zero(grid))
 end
 
-"""
-    basal_τx_coefficient(i, j, k, grid, basal_stress, fields)
-    basal_τy_coefficient(i, j, k, grid, basal_stress, fields)
-
-Return the coefficient ``τᵇ / u`` of the basal stress, for implicit treatment by the momentum solver.
-"""
+# Coefficient ``τᵇ / u``, for implicit treatment by the momentum solver.
 @inline function basal_τx_coefficient(i, j, k, grid, b::LandfastBasalStress, fields)
     kᵇ = ℑxᶠᵃᵃ(i, j, 1, grid, basal_stress_magnitude, b, fields)
     u  = @inbounds fields.u[i, j, k]

--- a/src/SeaIceDynamics/sea_ice_momentum_equations.jl
+++ b/src/SeaIceDynamics/sea_ice_momentum_equations.jl
@@ -1,12 +1,13 @@
 using ..Rheologies
 
-struct SeaIceMomentumEquation{S, C, R, F, A, ES, FT}
+struct SeaIceMomentumEquation{S, C, R, F, A, ES, B, FT}
     coriolis :: C
     rheology :: R
     auxiliaries :: A
     solver :: S
     free_drift :: F
     external_momentum_stresses :: ES
+    basal_stress :: B
     minimum_concentration :: FT
     minimum_mass :: FT
 end
@@ -21,6 +22,7 @@ struct ExplicitSolver end
                            top_momentum_stress    = nothing,
                            bottom_momentum_stress = nothing,
                            free_drift = nothing,
+                           basal_stress = nothing,
                            solver = SplitExplicitSolver(grid; substeps=150),
                            minimum_concentration = 1e-3,
                            minimum_mass = 1.0)
@@ -53,6 +55,10 @@ Keyword Arguments
                             be materialized into one. Default: `nothing`.
 - `free_drift`: The free drift velocities used when nonzero sea ice mass or concentration are below
                 the dynamical momentum thresholds. Default is `nothing`.
+- `basal_stress`: Stress exerted by the sea floor on grounded keels, arresting landfast ice over
+                  shallow bathymetry. Default: `nothing`. See [`LandfastBasalStress`](@ref). It is
+                  held apart from the external stresses because the sea floor, not the water column,
+                  carries it, so it never enters the stress handed back to an ocean model.
 - `solver`: Momentum solver used to advance the velocity field. Default:
             `SplitExplicitSolver(grid; substeps = 150)`.
 - `minimum_concentration`: Minimum sea-ice concentration above which the velocity
@@ -70,6 +76,7 @@ function SeaIceMomentumEquation(grid;
                                 top_momentum_stress    = nothing,
                                 bottom_momentum_stress = nothing,
                                 free_drift = nothing,
+                                basal_stress = nothing,
                                 solver = SplitExplicitSolver(grid; substeps=150),
                                 minimum_concentration = 1e-3,
                                 minimum_mass = 1.0)
@@ -80,6 +87,7 @@ function SeaIceMomentumEquation(grid;
 
     # Keep the free drift pointing at the same (materialized) stress fields as the external stresses.
     free_drift = materialize_free_drift(free_drift, external_momentum_stresses.top, external_momentum_stresses.bottom)
+    basal_stress = materialize_basal_stress(basal_stress, grid)
 
     FT = eltype(grid)
 
@@ -89,6 +97,7 @@ function SeaIceMomentumEquation(grid;
                                   solver,
                                   free_drift,
                                   external_momentum_stresses,
+                                  basal_stress,
                                   convert(FT, minimum_concentration),
                                   convert(FT, minimum_mass))
 end
@@ -108,6 +117,7 @@ function Base.show(io::IO, sime::SeaIceMomentumEquation)
     print(io, "├── coriolis: ", summary(sime.coriolis), '\n')
     print(io, "├── rheology: ", summary(sime.rheology), '\n')
     print(io, "├── auxiliaries: ", join(aux_fields, ", "), '\n')
+    print(io, "├── basal_stress: ", summary(sime.basal_stress), '\n')
     print(io, "├── solver: ", summary(sime.solver), '\n')
     print(io, "├── free_drift: ", sime.free_drift, '\n')
     print(io, "├── external_momentum_stresses: ", keys(sime.external_momentum_stresses), '\n')

--- a/src/SeaIceDynamics/sea_ice_momentum_equations.jl
+++ b/src/SeaIceDynamics/sea_ice_momentum_equations.jl
@@ -56,9 +56,7 @@ Keyword Arguments
 - `free_drift`: The free drift velocities used when nonzero sea ice mass or concentration are below
                 the dynamical momentum thresholds. Default is `nothing`.
 - `basal_stress`: Stress exerted by the sea floor on grounded keels, arresting landfast ice over
-                  shallow bathymetry. Default: `nothing`. See [`LandfastBasalStress`](@ref). It is
-                  held apart from the external stresses because the sea floor, not the water column,
-                  carries it, so it never enters the stress handed back to an ocean model.
+                  shallow bathymetry. Default: `nothing`. See [`LandfastBasalStress`](@ref).
 - `solver`: Momentum solver used to advance the velocity field. Default:
             `SplitExplicitSolver(grid; substeps = 150)`.
 - `minimum_concentration`: Minimum sea-ice concentration above which the velocity

--- a/src/SeaIceDynamics/split_explicit_momentum_equations.jl
+++ b/src/SeaIceDynamics/split_explicit_momentum_equations.jl
@@ -64,12 +64,12 @@ function maybe_extended_grid(solver::SplitExplicitSolver, grid::DistributedGrid)
 end
 
 function materialize_solver(mom::SplitExplicitMomentumEquation, grid)
-    new_auxiliarie s = Auxiliaries(mom.rheology, grid)
+    new_auxiliaries  = Auxiliaries(mom.rheology, grid)
     new_solver       = SplitExplicitSolver(grid; substeps = mom.solver.substeps)
     new_basal_stress = materialize_basal_stress(mom.basal_stress, grid)
     new_stress       = (bottom = materialize_stress(mom.external_momentum_stresses.bottom, grid),
-                       top    = materialize_stress(mom.external_momentum_stresses.top, grid))
-    
+                        top    = materialize_stress(mom.external_momentum_stresses.top, grid))
+
     # Repoint the free drift at the re-gridded stresses so it shares the same (extended) fields
     new_free_drift  = materialize_free_drift(mom.free_drift, new_stress.top, new_stress.bottom)
 
@@ -216,9 +216,9 @@ end
     # Implicit part of the stress that depends linearly on the velocity
     # The external stresses act over the ice-covered fraction; the basal stress already carries its
     # own concentration dependence
-    τuᵢ = ( implicit_τx_coefficient(i, j, kᴺ, grid, u_bottom_stress, clock, fields)
-          - implicit_τx_coefficient(i, j, kᴺ, grid, u_top_stress, clock, fields)) / mᵢ * ℵᵢ
-          + basal_τx_coefficient(i, j, kᴺ, grid, basal_stress, fields) / mᵢ
+    τuᵢ = ( implicit_τx_coefficient(i, j, kᴺ, grid, u_bottom_stress, clock, fields) / mᵢ * ℵᵢ
+          - implicit_τx_coefficient(i, j, kᴺ, grid, u_top_stress, clock, fields) / mᵢ * ℵᵢ
+          + basal_τx_coefficient(i, j, kᴺ, grid, basal_stress, fields) / mᵢ)
 
     τuᵢ = ifelse(mᵢ ≤ 0, zero(grid), τuᵢ)
     uᴰ  = @inbounds (u[i, j, 1] + Δτ * Gu) / (1 + Δτ * τuᵢ) # dynamical velocity
@@ -251,9 +251,9 @@ end
                              v_immersed_bc, v_top_stress, v_bottom_stress, v_forcing)
 
     # Implicit part of the stress that depends linearly on the velocity
-    τvᵢ = ( implicit_τy_coefficient(i, j, kᴺ, grid, v_bottom_stress, clock, fields)
-          - implicit_τy_coefficient(i, j, kᴺ, grid, v_top_stress, clock, fields)) / mᵢ * ℵᵢ
-          + basal_τy_coefficient(i, j, kᴺ, grid, basal_stress, fields) / mᵢ
+    τvᵢ = ( implicit_τy_coefficient(i, j, kᴺ, grid, v_bottom_stress, clock, fields) / mᵢ * ℵᵢ
+          - implicit_τy_coefficient(i, j, kᴺ, grid, v_top_stress, clock, fields) / mᵢ * ℵᵢ
+          + basal_τy_coefficient(i, j, kᴺ, grid, basal_stress, fields) / mᵢ)
 
     τvᵢ = ifelse(mᵢ ≤ 0, zero(grid), τvᵢ)
 

--- a/src/SeaIceDynamics/split_explicit_momentum_equations.jl
+++ b/src/SeaIceDynamics/split_explicit_momentum_equations.jl
@@ -64,11 +64,12 @@ function maybe_extended_grid(solver::SplitExplicitSolver, grid::DistributedGrid)
 end
 
 function materialize_solver(mom::SplitExplicitMomentumEquation, grid)
-    new_auxiliaries = Auxiliaries(mom.rheology, grid)
-    new_solver      = SplitExplicitSolver(grid; substeps = mom.solver.substeps)
-    new_stress      = (bottom = materialize_stress(mom.external_momentum_stresses.bottom, grid),
+    new_auxiliarie s = Auxiliaries(mom.rheology, grid)
+    new_solver       = SplitExplicitSolver(grid; substeps = mom.solver.substeps)
+    new_basal_stress = materialize_basal_stress(mom.basal_stress, grid)
+    new_stress       = (bottom = materialize_stress(mom.external_momentum_stresses.bottom, grid),
                        top    = materialize_stress(mom.external_momentum_stresses.top, grid))
-
+    
     # Repoint the free drift at the re-gridded stresses so it shares the same (extended) fields
     new_free_drift  = materialize_free_drift(mom.free_drift, new_stress.top, new_stress.bottom)
 
@@ -78,6 +79,7 @@ function materialize_solver(mom::SplitExplicitMomentumEquation, grid)
                                   new_solver,
                                   new_free_drift,
                                   new_stress,
+                                  new_basal_stress,
                                   mom.minimum_concentration,
                                   mom.minimum_mass)
 end
@@ -120,6 +122,7 @@ function time_step_momentum!(model, dynamics::SplitExplicitMomentumEquation, Δt
     u_immersed_bc = u.boundary_conditions.immersed
     v_immersed_bc = v.boundary_conditions.immersed
     top_stress    = dynamics.external_momentum_stresses.top
+    basal_stress  = dynamics.basal_stress
     bottom_stress = dynamics.external_momentum_stresses.bottom
     model_fields  = merge(dynamics.auxiliaries.fields, model.velocities,
                        (; h = model.ice_thickness,
@@ -140,8 +143,8 @@ function time_step_momentum!(model, dynamics::SplitExplicitMomentumEquation, Δt
 
     substeps = dynamics.solver.substeps
 
-    u_args = (u, grid, Δt, substeps, rheology, model_fields, free_drift, clock, coriolis, massmin, ℵmin, u_immersed_bc, top_stress, bottom_stress, u_forcing)
-    v_args = (v, grid, Δt, substeps, rheology, model_fields, free_drift, clock, coriolis, massmin, ℵmin, v_immersed_bc, top_stress, bottom_stress, v_forcing)
+    u_args = (u, grid, Δt, substeps, rheology, model_fields, free_drift, clock, coriolis, massmin, ℵmin, u_immersed_bc, top_stress, bottom_stress, basal_stress, u_forcing)
+    v_args = (v, grid, Δt, substeps, rheology, model_fields, free_drift, clock, coriolis, massmin, ℵmin, v_immersed_bc, top_stress, bottom_stress, basal_stress, v_forcing)
 
     u_fill_halo_args = (u.data, u.boundary_conditions, u.indices, instantiated_location(u), grid, u.communication_buffers)
     v_fill_halo_args = (v.data, v.boundary_conditions, v.indices, instantiated_location(v), grid, v.communication_buffers)
@@ -197,7 +200,7 @@ end
 @kernel function _u_velocity_step!(u, grid, Δt, substeps, rheology,
                                    fields, free_drift, clock, coriolis,
                                    minimum_mass, minimum_concentration,
-                                   u_immersed_bc, u_top_stress, u_bottom_stress, u_forcing)
+                                   u_immersed_bc, u_top_stress, u_bottom_stress, basal_stress, u_forcing)
 
     i, j = @index(Global, NTuple)
     kᴺ   = size(grid, 3)
@@ -211,8 +214,11 @@ end
                              u_immersed_bc, u_top_stress, u_bottom_stress, u_forcing)
 
     # Implicit part of the stress that depends linearly on the velocity
+    # The external stresses act over the ice-covered fraction; the basal stress already carries its
+    # own concentration dependence
     τuᵢ = ( implicit_τx_coefficient(i, j, kᴺ, grid, u_bottom_stress, clock, fields)
           - implicit_τx_coefficient(i, j, kᴺ, grid, u_top_stress, clock, fields)) / mᵢ * ℵᵢ
+          + basal_τx_coefficient(i, j, kᴺ, grid, basal_stress, fields) / mᵢ
 
     τuᵢ = ifelse(mᵢ ≤ 0, zero(grid), τuᵢ)
     uᴰ  = @inbounds (u[i, j, 1] + Δτ * Gu) / (1 + Δτ * τuᵢ) # dynamical velocity
@@ -231,7 +237,7 @@ end
 @kernel function _v_velocity_step!(v, grid, Δt, substeps, rheology,
                                    fields, free_drift, clock, coriolis,
                                    minimum_mass, minimum_concentration,
-                                   v_immersed_bc, v_top_stress, v_bottom_stress, v_forcing)
+                                   v_immersed_bc, v_top_stress, v_bottom_stress, basal_stress, v_forcing)
 
     i, j = @index(Global, NTuple)
     kᴺ   = size(grid, 3)
@@ -247,6 +253,7 @@ end
     # Implicit part of the stress that depends linearly on the velocity
     τvᵢ = ( implicit_τy_coefficient(i, j, kᴺ, grid, v_bottom_stress, clock, fields)
           - implicit_τy_coefficient(i, j, kᴺ, grid, v_top_stress, clock, fields)) / mᵢ * ℵᵢ
+          + basal_τy_coefficient(i, j, kᴺ, grid, basal_stress, fields) / mᵢ
 
     τvᵢ = ifelse(mᵢ ≤ 0, zero(grid), τvᵢ)
 

--- a/src/SeaIceDynamics/split_explicit_momentum_equations.jl
+++ b/src/SeaIceDynamics/split_explicit_momentum_equations.jl
@@ -213,9 +213,7 @@ end
     Gu = u_velocity_tendency(i, j, grid, Δτ, rheology, fields, clock, coriolis,
                              u_immersed_bc, u_top_stress, u_bottom_stress, u_forcing)
 
-    # Implicit part of the stress that depends linearly on the velocity
-    # The external stresses act over the ice-covered fraction; the basal stress already carries its
-    # own concentration dependence
+    # The external stresses act over the ice-covered fraction; the basal stress carries its own
     τuᵢ = ( implicit_τx_coefficient(i, j, kᴺ, grid, u_bottom_stress, clock, fields) / mᵢ * ℵᵢ
           - implicit_τx_coefficient(i, j, kᴺ, grid, u_top_stress, clock, fields) / mᵢ * ℵᵢ
           + basal_τx_coefficient(i, j, kᴺ, grid, basal_stress, fields) / mᵢ)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,10 @@ if TEST_GROUP == "all" || TEST_GROUP == "advection"
     include("test_sea_ice_advection.jl")
 end
 
+if TEST_GROUP == "all" || TEST_GROUP == "basal_stress"
+    include("test_landfast_basal_stress.jl")
+end
+
 if TEST_GROUP == "all" || TEST_GROUP == "timestepping"
     include("test_time_stepping.jl")
 end

--- a/test/test_landfast_basal_stress.jl
+++ b/test/test_landfast_basal_stress.jl
@@ -5,7 +5,7 @@ using ClimaSeaIce
 using ClimaSeaIce.SeaIceDynamics: basal_τx_coefficient, basal_τy_coefficient,
                                   materialize_basal_stress, basal_stress_magnitude
 using Oceananigans.Fields: interior
-using Oceananigans.Grids: Face, Center
+using Oceananigans.Grids: Face, Center, static_column_depthᶜᶜᵃ
 
 # A shelf shallow enough to ground keels next to water too deep to ground anything. The vertical grid
 # must resolve the shelf: with cells thicker than the shelf depth the whole top cell is immersed and
@@ -28,19 +28,19 @@ end
 
 @testset "LandfastBasalStress construction" begin
     b = LandfastBasalStress()
-    @test b.water_depth isa Nothing
     @test b.critical_thickness_parameter == 8
     @test b.stress_parameter == 15
     @test b.concentration_hardening == 20
     @test b.minimum_speed == 5e-5
     @test b.maximum_water_depth == 30
 
+    # The depth is read off the grid, so the shelf has to survive the immersed-boundary discretization.
     grid = shelf_grid()
-    bm = materialize_basal_stress(b, grid)
-    H = interior(bm.water_depth)[:, :, 1]
+    H = [static_column_depthᶜᶜᵃ(i, j, grid) for i in 1:8, j in 1:8]
     @test all(H[1:4, :] .≈ 20)
     @test all(H[5:8, :] .≈ 40)
 
+    @test materialize_basal_stress(b, grid) === b
     @test materialize_basal_stress(nothing, grid) isa Nothing
 end
 
@@ -98,7 +98,6 @@ end
 
     dyn = SeaIceMomentumEquation(grid; basal_stress = LandfastBasalStress())
     @test dyn.basal_stress isa LandfastBasalStress
-    @test dyn.basal_stress.water_depth isa Field       # materialized on the grid
 
     # It is held apart from the stresses the water column exerts, so a coupler reading those never
     # sees the part of the drag that the sea floor carries.

--- a/test/test_landfast_basal_stress.jl
+++ b/test/test_landfast_basal_stress.jl
@@ -1,0 +1,139 @@
+using Test
+using Oceananigans
+using ClimaSeaIce
+
+using ClimaSeaIce.SeaIceDynamics: basal_τx_coefficient, basal_τy_coefficient,
+                                  materialize_basal_stress, basal_stress_magnitude
+using Oceananigans.Fields: interior
+using Oceananigans.Grids: Face, Center
+
+# A shelf shallow enough to ground keels next to water too deep to ground anything. The vertical grid
+# must resolve the shelf: with cells thicker than the shelf depth the whole top cell is immersed and
+# the column depth collapses to zero.
+function shelf_grid(arch = CPU(); Nx = 8, Ny = 8, Nz = 8)
+    underlying = RectilinearGrid(arch; size = (Nx, Ny, Nz), x = (0, 8e4), y = (0, 8e4), z = (-40, 0),
+                                 topology = (Bounded, Bounded, Bounded))
+    bottom = [i <= Nx ÷ 2 ? -20.0 : -40.0 for i in 1:Nx, j in 1:Ny]
+    return ImmersedBoundaryGrid(underlying, GridFittedBottom(bottom))
+end
+
+ice_fields(grid; h = 3.0, ℵ = 1.0, u = 0.1, v = 0.0) = begin
+    hf = Field{Center, Center, Nothing}(grid); set!(hf, h)
+    ℵf = Field{Center, Center, Nothing}(grid); set!(ℵf, ℵ)
+    ρf = Field{Center, Center, Nothing}(grid); set!(ρf, 900.0)
+    uf = Field{Face,   Center, Nothing}(grid); set!(uf, u)
+    vf = Field{Center, Face,   Nothing}(grid); set!(vf, v)
+    (; h = hf, ℵ = ℵf, ρ = ρf, u = uf, v = vf)
+end
+
+@testset "LandfastBasalStress construction" begin
+    b = LandfastBasalStress()
+    @test b.water_depth isa Nothing
+    @test b.critical_thickness_parameter == 8
+    @test b.stress_parameter == 15
+    @test b.concentration_hardening == 20
+    @test b.minimum_speed == 5e-5
+    @test b.maximum_water_depth == 30
+
+    grid = shelf_grid()
+    bm = materialize_basal_stress(b, grid)
+    H = interior(bm.water_depth)[:, :, 1]
+    @test all(H[1:4, :] .≈ 20)
+    @test all(H[5:8, :] .≈ 40)
+
+    @test materialize_basal_stress(nothing, grid) isa Nothing
+end
+
+@testset "Grounding criterion" begin
+    grid = shelf_grid()
+    bm = materialize_basal_stress(LandfastBasalStress(), grid)
+    kᴺ = size(grid, 3)
+
+    fields = ice_fields(grid)   # h = 3 m, ℵ = 1, u = 0.1 m/s
+    shelf = basal_τx_coefficient(2, 4, kᴺ, grid, bm, fields)
+    deep  = basal_τx_coefficient(7, 4, kᴺ, grid, bm, fields)
+
+    # hᶜ = H ℵ / k₁ = 20/8 = 2.5 m, so 3 m of ice grounds on the shelf.
+    @test shelf ≈ 15 * (3.0 - 20/8) / (0.1 + 5e-5)
+    @test deep == 0                       # 40 m exceeds maximum_water_depth
+
+    # τᵇ saturates at k₂ δh: it can arrest ice but never accelerate it.
+    @test shelf * 0.1 < 15 * (3.0 - 20/8)
+
+    # Thin ice cannot ground even on the shelf.
+    @test basal_τx_coefficient(2, 4, kᴺ, grid, materialize_basal_stress(LandfastBasalStress(), grid),
+                               ice_fields(grid; h = 1.0)) == 0
+
+    # Unconsolidated ice is released by the concentration hardening.
+    loose = basal_τx_coefficient(2, 4, kᴺ, grid, bm, ice_fields(grid; ℵ = 0.5))
+    @test 0 < loose < shelf
+
+    # Slower ice feels a larger coefficient, so the stress saturates rather than the drag vanishing.
+    @test basal_τx_coefficient(2, 4, kᴺ, grid, bm, ice_fields(grid; u = 0.01)) > shelf
+
+    @test basal_τx_coefficient(2, 4, kᴺ, grid, nothing, fields) == 0
+    @test basal_τy_coefficient(2, 4, kᴺ, grid, nothing, fields) == 0
+end
+
+@testset "Grounding is a cell-centred property" begin
+    grid = shelf_grid()
+    bm = materialize_basal_stress(LandfastBasalStress(), grid)
+    kᴺ = size(grid, 3)
+    fields = ice_fields(grid)
+
+    # The magnitude is formed at centres, so the shelf cell carries the full grounding, and the
+    # velocity point straddling the shelf break gets the average of its two neighbours.
+    mˢ = basal_stress_magnitude(4, 4, kᴺ, grid, bm, fields)
+    mᵈ = basal_stress_magnitude(5, 4, kᴺ, grid, bm, fields)
+    @test mˢ ≈ 15 * (3.0 - 20/8)
+    @test mᵈ == 0
+    @test basal_τx_coefficient(5, 4, kᴺ, grid, bm, fields) ≈ (mˢ + mᵈ) / 2 / (0.1 + 5e-5)
+end
+
+@testset "SeaIceMomentumEquation carries the basal stress" begin
+    grid = shelf_grid()
+
+    plain = SeaIceMomentumEquation(grid)
+    @test plain.basal_stress isa Nothing
+
+    dyn = SeaIceMomentumEquation(grid; basal_stress = LandfastBasalStress())
+    @test dyn.basal_stress isa LandfastBasalStress
+    @test dyn.basal_stress.water_depth isa Field       # materialized on the grid
+
+    # It is held apart from the stresses the water column exerts, so a coupler reading those never
+    # sees the part of the drag that the sea floor carries.
+    @test !(:basal in propertynames(dyn.external_momentum_stresses))
+end
+
+function drift_after_a_step(; grounded, Δt = 600, nsteps = 20)
+    grid = shelf_grid()
+    basal_stress = grounded ? LandfastBasalStress() : nothing
+    dynamics = SeaIceMomentumEquation(grid; coriolis = nothing, basal_stress,
+                                      rheology = ElastoViscoPlasticRheology(),
+                                      solver = SplitExplicitSolver(grid; substeps = 50))
+    model = SeaIceModel(grid; dynamics, advection = nothing)
+    set!(model, h = 3.0, ℵ = 1.0)
+    set!(model.velocities.u, 0.1)
+    for _ in 1:nsteps
+        time_step!(model, Δt)
+    end
+    return Array(interior(model.velocities.u))[:, :, 1]
+end
+
+@testset "Grounded ice is arrested, deep ice is not" begin
+    uᶠ = drift_after_a_step(grounded = false)
+    uᵍ = drift_after_a_step(grounded = true)
+
+    @test all(isfinite, uᶠ)
+    @test all(isfinite, uᵍ)
+
+    # Columns 1:4 sit on the 20 m shelf and ground; 6:8 are in 40 m water and cannot. The deep ice
+    # is not perfectly untouched: ice is a continuum, so the arrested belt drags on its neighbours
+    # through the internal stress. What must hold is the contrast, not decoupling.
+    shelf_slowdown = 1 - maximum(abs, uᵍ[2:4, :]) / maximum(abs, uᶠ[2:4, :])
+    deep_slowdown  = 1 - abs(uᵍ[7, 4]) / abs(uᶠ[7, 4])
+
+    @test shelf_slowdown > 0.5
+    @test deep_slowdown < 0.05
+    @test shelf_slowdown > 10 * deep_slowdown
+end

--- a/test/test_landfast_basal_stress.jl
+++ b/test/test_landfast_basal_stress.jl
@@ -2,14 +2,11 @@ using Test
 using Oceananigans
 using ClimaSeaIce
 
-using ClimaSeaIce.SeaIceDynamics: basal_τx_coefficient, basal_τy_coefficient,
-                                  materialize_basal_stress, basal_stress_magnitude
+using ClimaSeaIce.SeaIceDynamics: basal_τx_coefficient, basal_τy_coefficient, basal_stress_magnitude
 using Oceananigans.Fields: interior
 using Oceananigans.Grids: Face, Center, static_column_depthᶜᶜᵃ
 
-# A shelf shallow enough to ground keels next to water too deep to ground anything. The vertical grid
-# must resolve the shelf: with cells thicker than the shelf depth the whole top cell is immersed and
-# the column depth collapses to zero.
+# A shelf shallow enough to ground keels next to water too deep to ground anything.
 function shelf_grid(arch = CPU(); Nx = 8, Ny = 8, Nz = 8)
     underlying = RectilinearGrid(arch; size = (Nx, Ny, Nz), x = (0, 8e4), y = (0, 8e4), z = (-40, 0),
                                  topology = (Bounded, Bounded, Bounded))
@@ -26,27 +23,16 @@ ice_fields(grid; h = 3.0, ℵ = 1.0, u = 0.1, v = 0.0) = begin
     (; h = hf, ℵ = ℵf, ρ = ρf, u = uf, v = vf)
 end
 
-@testset "LandfastBasalStress construction" begin
-    b = LandfastBasalStress()
-    @test b.critical_thickness_parameter == 8
-    @test b.stress_parameter == 15
-    @test b.concentration_hardening == 20
-    @test b.minimum_speed == 5e-5
-    @test b.maximum_water_depth == 30
-
-    # The depth is read off the grid, so the shelf has to survive the immersed-boundary discretization.
+@testset "The shelf survives the immersed-boundary discretization" begin
     grid = shelf_grid()
     H = [static_column_depthᶜᶜᵃ(i, j, grid) for i in 1:8, j in 1:8]
     @test all(H[1:4, :] .≈ 20)
     @test all(H[5:8, :] .≈ 40)
-
-    @test materialize_basal_stress(b, grid) === b
-    @test materialize_basal_stress(nothing, grid) isa Nothing
 end
 
 @testset "Grounding criterion" begin
     grid = shelf_grid()
-    bm = materialize_basal_stress(LandfastBasalStress(), grid)
+    bm = LandfastBasalStress()
     kᴺ = size(grid, 3)
 
     fields = ice_fields(grid)   # h = 3 m, ℵ = 1, u = 0.1 m/s
@@ -61,8 +47,7 @@ end
     @test shelf * 0.1 < 15 * (3.0 - 20/8)
 
     # Thin ice cannot ground even on the shelf.
-    @test basal_τx_coefficient(2, 4, kᴺ, grid, materialize_basal_stress(LandfastBasalStress(), grid),
-                               ice_fields(grid; h = 1.0)) == 0
+    @test basal_τx_coefficient(2, 4, kᴺ, grid, bm, ice_fields(grid; h = 1.0)) == 0
 
     # Unconsolidated ice is released by the concentration hardening.
     loose = basal_τx_coefficient(2, 4, kᴺ, grid, bm, ice_fields(grid; ℵ = 0.5))
@@ -77,17 +62,16 @@ end
 
 @testset "Grounding is a cell-centred property" begin
     grid = shelf_grid()
-    bm = materialize_basal_stress(LandfastBasalStress(), grid)
+    bm = LandfastBasalStress()
     kᴺ = size(grid, 3)
     fields = ice_fields(grid)
 
-    # The magnitude is formed at centres, so the shelf cell carries the full grounding, and the
-    # velocity point straddling the shelf break gets the average of its two neighbours.
-    mˢ = basal_stress_magnitude(4, 4, kᴺ, grid, bm, fields)
-    mᵈ = basal_stress_magnitude(5, 4, kᴺ, grid, bm, fields)
-    @test mˢ ≈ 15 * (3.0 - 20/8)
-    @test mᵈ == 0
-    @test basal_τx_coefficient(5, 4, kᴺ, grid, bm, fields) ≈ (mˢ + mᵈ) / 2 / (0.1 + 5e-5)
+    # The velocity point straddling the shelf break gets the average of its two neighbours.
+    shelf_magnitude = basal_stress_magnitude(4, 4, kᴺ, grid, bm, fields)
+    deep_magnitude = basal_stress_magnitude(5, 4, kᴺ, grid, bm, fields)
+    @test shelf_magnitude ≈ 15 * (3.0 - 20/8)
+    @test deep_magnitude == 0
+    @test basal_τx_coefficient(5, 4, kᴺ, grid, bm, fields) ≈ (shelf_magnitude + deep_magnitude) / 2 / (0.1 + 5e-5)
 end
 
 @testset "SeaIceMomentumEquation carries the basal stress" begin
@@ -99,8 +83,6 @@ end
     dyn = SeaIceMomentumEquation(grid; basal_stress = LandfastBasalStress())
     @test dyn.basal_stress isa LandfastBasalStress
 
-    # It is held apart from the stresses the water column exerts, so a coupler reading those never
-    # sees the part of the drag that the sea floor carries.
     @test !(:basal in propertynames(dyn.external_momentum_stresses))
 end
 
@@ -126,9 +108,7 @@ end
     @test all(isfinite, uᶠ)
     @test all(isfinite, uᵍ)
 
-    # Columns 1:4 sit on the 20 m shelf and ground; 6:8 are in 40 m water and cannot. The deep ice
-    # is not perfectly untouched: ice is a continuum, so the arrested belt drags on its neighbours
-    # through the internal stress. What must hold is the contrast, not decoupling.
+    # Columns 1:4 sit on the 20 m shelf and ground; 6:8 are in 40 m water and cannot.
     shelf_slowdown = 1 - maximum(abs, uᵍ[2:4, :]) / maximum(abs, uᶠ[2:4, :])
     deep_slowdown  = 1 - abs(uᵍ[7, 4]) / abs(uᶠ[7, 4])
 


### PR DESCRIPTION
Stress acted by the bathymetry on shallow sea-ice regions. It is linear in the velocity so it is fully implicit.
It is treated differently from the bottom stress since it is felt and acted upon by the bathymetry and not by the ocean, so it is a particular stress that does not need passing to the ocean model in a coupler.