### PR TITLE
Backport incremental remapping for sea-ice transport

### DIFF
--- a/src/ClimaSeaIce.jl
+++ b/src/ClimaSeaIce.jl
@@ -8,6 +8,7 @@ module ClimaSeaIce
 end ClimaSeaIce
 
 export SeaIceModel,
+       IncrementalRemapping,
        MeltingConstrainedFluxBalance,
        PrescribedTemperature,
        RadiativeEmission,
@@ -62,6 +63,7 @@ using .Rheologies
 # Timestepping
 include("sea_ice_fe_step.jl")
 include("sea_ice_rk_substep.jl")
+include("incremental_remapping.jl")
 
 # Advection timescale for a `SeaIceModel`. Sea ice dynamics are two-dimensional so
 # we reuse the `cell_advection_timescale` function defined in Oceananigans by passing

--- a/src/forward_euler_timestepper.jl
+++ b/src/forward_euler_timestepper.jl
@@ -56,3 +56,6 @@ Oceananigans.TimeSteppers.reset!(::ForwardEulerTimeStepper) = nothing
 # Forward Euler is a self-starting timestepper, so no state needs to be saved
 Oceananigans.prognostic_state(::ForwardEulerTimeStepper) = nothing
 Oceananigans.restore_prognostic_state!(ts::ForwardEulerTimeStepper, ::Nothing) = ts
+
+# Forward Euler starts from the restored fields and needs no Runge-Kutta history.
+Oceananigans.restore_prognostic_state!(ts::ForwardEulerTimeStepper, ::NamedTuple) = ts

--- a/src/incremental_remapping.jl
+++ b/src/incremental_remapping.jl
@@ -122,7 +122,7 @@ end
 @inline function iced_thickness(i, j, k, grid, h, ℵ, h₀)
     @inbounds ℵᵢ = ℵ[i, j, k]
     @inbounds hᵢ = h[i, j, k]
-    ℵᵐⁱⁿ = minimum_ice_concentration(typeof(h₀))
+    ℵᵐⁱⁿ = zero(h₀)
     iced = (ℵᵢ > ℵᵐⁱⁿ) & !submerged(i, j, k, grid)
     return ifelse(iced, hᵢ, h₀)
 end
@@ -212,7 +212,7 @@ end
     ℵy = α * ℵy
 
     # xa = ∫ℵ̃ x dA / ∫ℵ̃ dA = ℵx Δx² / (12 ℵ₀), measured from the cell centre, and likewise in y
-    ℵᵐⁱⁿ = minimum_ice_concentration(typeof(ℵ₀))
+    ℵᵐⁱⁿ = zero(ℵ₀)
     iced = ℵ₀ > ℵᵐⁱⁿ
     xa = ifelse(iced, ℵx * Δx^2 / (12 * ℵ₀), zero(ℵ₀))
     ya = ifelse(iced, ℵy * Δy^2 / (12 * ℵ₀), zero(ℵ₀))

--- a/src/incremental_remapping.jl
+++ b/src/incremental_remapping.jl
@@ -1,0 +1,498 @@
+# Adapted from Simone Silvestri's ss/for-omip branch, commit f9a579ad9869d9b04cf3d052267c5fcce22c0baf.
+using Adapt: Adapt
+using Oceananigans.Grids: halo_size
+using Oceananigans.ImmersedBoundaries: immersed_cell
+using Oceananigans.Operators: Δxᶜᶜᶜ, Δyᶜᶜᶜ, Δxᶠᶜᶜ, Δyᶠᶜᶜ, Δxᶜᶠᶜ, Δyᶜᶠᶜ, ℑxᶠᵃᵃ, ℑyᵃᶠᵃ
+using Oceananigans.Utils: KernelParameters
+
+"""
+    IncrementalRemapping(; quadrature_nodes=3)
+
+Transport ice concentration, ice volume, and snow volume together using the
+incremental remapping method of Lipscomb and Hunke (2004). Reconstruct limited
+linear profiles in each cell and integrate the material that crosses each face.
+
+Use `timestepper=:ForwardEuler`, horizontal halos of at least two cells, and
+an advective Courant number below one in each direction. `quadrature_nodes`
+sets the number of integration points in each direction (one to four).
+"""
+struct IncrementalRemapping{N, R, T}
+    reconstruction :: R
+    transports :: T
+end
+
+function IncrementalRemapping(; quadrature_nodes::Int=3)
+    1 <= quadrature_nodes <= 4 || throw(ArgumentError("quadrature_nodes must be between 1 and 4"))
+    return IncrementalRemapping{quadrature_nodes, Nothing, Nothing}(nothing, nothing)
+end
+
+Base.summary(::IncrementalRemapping{N}) where N = string("IncrementalRemapping(quadrature_nodes=", N, ")")
+Base.show(io::IO, scheme::IncrementalRemapping) = print(io, summary(scheme))
+
+Oceananigans.Grids.required_halo_size_x(::IncrementalRemapping) = 2
+Oceananigans.Grids.required_halo_size_y(::IncrementalRemapping) = 2
+
+function Adapt.adapt_structure(to, scheme::IncrementalRemapping{N}) where N
+    reconstruction = Adapt.adapt(to, scheme.reconstruction)
+    transports = Adapt.adapt(to, scheme.transports)
+    return IncrementalRemapping{N, typeof(reconstruction), typeof(transports)}(reconstruction, transports)
+end
+
+function Oceananigans.Advection.materialize_advection(scheme::IncrementalRemapping{N, Nothing}, grid) where N
+    Hx, Hy, _ = halo_size(grid)
+
+    if Hx < 2 || Hy < 2
+        throw(ArgumentError("IncrementalRemapping requires a horizontal halo of at least 2, got ($Hx, $Hy)"))
+    end
+
+    center_field() = Field{Center, Center, Nothing}(grid)
+
+    # `(xa, ya)` is the centroid of the reconstructed ice area, which anchors the tracer reconstructions.
+    reconstruction = (ℵx = center_field(), ℵy = center_field(),
+                      hx = center_field(), hy = center_field(),
+                      hsx = center_field(), hsy = center_field(),
+                      xa = center_field(), ya = center_field())
+
+    transports = (x = (ℵ = Field{Face, Center, Nothing}(grid),
+                       𝓋 = Field{Face, Center, Nothing}(grid),
+                       𝓋s = Field{Face, Center, Nothing}(grid)),
+                  y = (ℵ = Field{Center, Face, Nothing}(grid),
+                       𝓋 = Field{Center, Face, Nothing}(grid),
+                       𝓋s = Field{Center, Face, Nothing}(grid)))
+
+    R = typeof(reconstruction)
+    T = typeof(transports)
+
+    return IncrementalRemapping{N, R, T}(reconstruction, transports)
+end
+
+validate_advection_timestepper(::IncrementalRemapping, timestepper) =
+    throw(ArgumentError("IncrementalRemapping requires timestepper = :ForwardEuler, got $(summary(timestepper))"))
+
+validate_advection_timestepper(::IncrementalRemapping, ::ForwardEulerTimeStepper) = nothing
+
+@inline minimum_ice_concentration(FT, ::IncrementalRemapping) = zero(FT)
+
+#####
+##### Gauss--Legendre rules on the unit interval
+#####
+
+@inline quadrature_rule(FT, ::Val{1}) = ((FT(1/2), FT(1)),)
+
+@inline quadrature_rule(FT, ::Val{2}) = ((FT(1/2) - FT(0.28867513459481287), FT(1/2)),
+                                         (FT(1/2) + FT(0.28867513459481287), FT(1/2)))
+
+@inline quadrature_rule(FT, ::Val{3}) = ((FT(1/2) - FT(0.3872983346207417), FT(5/18)),
+                                         (FT(1/2),                          FT(8/18)),
+                                         (FT(1/2) + FT(0.3872983346207417), FT(5/18)))
+
+@inline quadrature_rule(FT, ::Val{4}) = ((FT(1/2) - FT(0.43056815579702629), FT(0.17392742256872693)),
+                                         (FT(1/2) - FT(0.16999052179242816), FT(0.32607257743127307)),
+                                         (FT(1/2) + FT(0.16999052179242816), FT(0.32607257743127307)),
+                                         (FT(1/2) + FT(0.43056815579702629), FT(0.17392742256872693)))
+
+#####
+##### Limited linear reconstruction
+#####
+
+@inline submerged(i, j, k, grid) = false
+@inline submerged(i, j, k, ibg::ImmersedBoundaryGrid) = immersed_cell(i, j, k, ibg)
+
+@inline wet_value(i, j, k, grid, c, c₀) = @inbounds ifelse(submerged(i, j, k, grid), c₀, c[i, j, k])
+
+@inline function neighborhood_extrema(i, j, k, grid, c)
+    @inbounds c₀ = c[i, j, k]
+
+    cᵂ  = wet_value(i-1, j,   k, grid, c, c₀)
+    cᴱ  = wet_value(i+1, j,   k, grid, c, c₀)
+    cˢ  = wet_value(i,   j-1, k, grid, c, c₀)
+    cᴺ  = wet_value(i,   j+1, k, grid, c, c₀)
+    cˢᵂ = wet_value(i-1, j-1, k, grid, c, c₀)
+    cˢᴱ = wet_value(i+1, j-1, k, grid, c, c₀)
+    cᴺᵂ = wet_value(i-1, j+1, k, grid, c, c₀)
+    cᴺᴱ = wet_value(i+1, j+1, k, grid, c, c₀)
+
+    cmin = min(c₀, cᵂ, cᴱ, cˢ, cᴺ, cˢᵂ, cˢᴱ, cᴺᵂ, cᴺᴱ)
+    cmax = max(c₀, cᵂ, cᴱ, cˢ, cᴺ, cˢᵂ, cˢᴱ, cᴺᴱ, cᴺᵂ)
+    return cmin, cmax
+end
+
+# Thickness of a neighbour, replaced by the local value where that neighbour carries no ice, so open
+# water does not drag the thickness reconstruction of an ice-covered cell toward zero.
+@inline function iced_thickness(i, j, k, grid, h, ℵ, h₀)
+    @inbounds ℵᵢ = ℵ[i, j, k]
+    @inbounds hᵢ = h[i, j, k]
+    ℵᵐⁱⁿ = minimum_ice_concentration(typeof(h₀))
+    iced = (ℵᵢ > ℵᵐⁱⁿ) & !submerged(i, j, k, grid)
+    return ifelse(iced, hᵢ, h₀)
+end
+
+@inline function iced_extrema(i, j, k, grid, h, ℵ, h₀)
+    hᵂ  = iced_thickness(i-1, j,   k, grid, h, ℵ, h₀)
+    hᴱ  = iced_thickness(i+1, j,   k, grid, h, ℵ, h₀)
+    hˢ  = iced_thickness(i,   j-1, k, grid, h, ℵ, h₀)
+    hᴺ  = iced_thickness(i,   j+1, k, grid, h, ℵ, h₀)
+    hˢᵂ = iced_thickness(i-1, j-1, k, grid, h, ℵ, h₀)
+    hˢᴱ = iced_thickness(i+1, j-1, k, grid, h, ℵ, h₀)
+    hᴺᵂ = iced_thickness(i-1, j+1, k, grid, h, ℵ, h₀)
+    hᴺᴱ = iced_thickness(i+1, j+1, k, grid, h, ℵ, h₀)
+
+    hmin = min(h₀, hᵂ, hᴱ, hˢ, hᴺ, hˢᵂ, hˢᴱ, hᴺᵂ, hᴺᴱ)
+    hmax = max(h₀, hᵂ, hᴱ, hˢ, hᴺ, hˢᵂ, hˢᴱ, hᴺᵂ, hᴺᴱ)
+    return hmin, hmax
+end
+
+# Barth--Jespersen scaling: the largest α ≤ 1 keeping the reconstruction within the neighbourhood
+# bounds over a cell whose extreme corner sits `δ` away from the anchor.
+@inline function limiting_factor(δ, c₀, cmin, cmax)
+    α = min(one(δ), (cmax - c₀) / δ, (c₀ - cmin) / δ)
+    return ifelse(δ > 0, α, one(δ))
+end
+
+@inline function centered_x_gradient(i, j, k, grid, c)
+    @inbounds c₀ = c[i, j, k]
+    δc = wet_value(i+1, j, k, grid, c, c₀) - wet_value(i-1, j, k, grid, c, c₀)
+    return δc / (Δxᶠᶜᶜ(i, j, k, grid) + Δxᶠᶜᶜ(i+1, j, k, grid))
+end
+
+@inline function centered_y_gradient(i, j, k, grid, c)
+    @inbounds c₀ = c[i, j, k]
+    δc = wet_value(i, j+1, k, grid, c, c₀) - wet_value(i, j-1, k, grid, c, c₀)
+    return δc / (Δyᶜᶠᶜ(i, j, k, grid) + Δyᶜᶠᶜ(i, j+1, k, grid))
+end
+
+@inline function iced_x_gradient(i, j, k, grid, h, ℵ, h₀)
+    δh = iced_thickness(i+1, j, k, grid, h, ℵ, h₀) - iced_thickness(i-1, j, k, grid, h, ℵ, h₀)
+    return δh / (Δxᶠᶜᶜ(i, j, k, grid) + Δxᶠᶜᶜ(i+1, j, k, grid))
+end
+
+@inline function iced_y_gradient(i, j, k, grid, h, ℵ, h₀)
+    δh = iced_thickness(i, j+1, k, grid, h, ℵ, h₀) - iced_thickness(i, j-1, k, grid, h, ℵ, h₀)
+    return δh / (Δyᶜᶠᶜ(i, j, k, grid) + Δyᶜᶠᶜ(i, j+1, k, grid))
+end
+
+# Anchoring at the area centroid `(xa, ya)` makes the area-weighted mean of the reconstruction return
+# the cell mean exactly.
+@inline function limited_tracer_gradients(i, j, k, grid, h, ℵ, xa, ya, Δx, Δy)
+    @inbounds h₀ = h[i, j, k]
+
+    hx = iced_x_gradient(i, j, k, grid, h, ℵ, h₀)
+    hy = iced_y_gradient(i, j, k, grid, h, ℵ, h₀)
+
+    hmin, hmax = iced_extrema(i, j, k, grid, h, ℵ, h₀)
+
+    δh = abs(hx) * (Δx / 2 + abs(xa)) + abs(hy) * (Δy / 2 + abs(ya))
+    α = limiting_factor(δh, h₀, hmin, hmax)
+
+    return α * hx, α * hy
+end
+
+@inline limited_tracer_gradients(i, j, k, grid, ::Nothing, ℵ, xa, ya, Δx, Δy) = zero(grid), zero(grid)
+
+@kernel function _compute_remapping_reconstruction!(reconstruction, grid, ℵ, h, hs)
+    i, j = @index(Global, NTuple)
+    k = size(grid, 3)
+
+    Δx = Δxᶜᶜᶜ(i, j, k, grid)
+    Δy = Δyᶜᶜᶜ(i, j, k, grid)
+
+    @inbounds ℵ₀ = ℵ[i, j, k]
+
+    ℵx = centered_x_gradient(i, j, k, grid, ℵ)
+    ℵy = centered_y_gradient(i, j, k, grid, ℵ)
+
+    ℵmin, ℵmax = neighborhood_extrema(i, j, k, grid, ℵ)
+
+    δℵ = abs(ℵx) * Δx / 2 + abs(ℵy) * Δy / 2
+    α = limiting_factor(δℵ, ℵ₀, ℵmin, ℵmax)
+
+    α = ifelse(submerged(i, j, k, grid), zero(α), α)
+
+    ℵx = α * ℵx
+    ℵy = α * ℵy
+
+    # xa = ∫ℵ̃ x dA / ∫ℵ̃ dA = ℵx Δx² / (12 ℵ₀), measured from the cell centre, and likewise in y
+    ℵᵐⁱⁿ = minimum_ice_concentration(typeof(ℵ₀))
+    iced = ℵ₀ > ℵᵐⁱⁿ
+    xa = ifelse(iced, ℵx * Δx^2 / (12 * ℵ₀), zero(ℵ₀))
+    ya = ifelse(iced, ℵy * Δy^2 / (12 * ℵ₀), zero(ℵ₀))
+
+    hx, hy = limited_tracer_gradients(i, j, k, grid, h, ℵ, xa, ya, Δx, Δy)
+    hsx, hsy = limited_tracer_gradients(i, j, k, grid, hs, ℵ, xa, ya, Δx, Δy)
+
+    @inbounds begin
+        reconstruction.ℵx[i, j, 1] = ℵx
+        reconstruction.ℵy[i, j, 1] = ℵy
+        reconstruction.hx[i, j, 1] = hx
+        reconstruction.hy[i, j, 1] = hy
+        reconstruction.hsx[i, j, 1] = hsx
+        reconstruction.hsy[i, j, 1] = hsy
+        reconstruction.xa[i, j, 1] = xa
+        reconstruction.ya[i, j, 1] = ya
+    end
+end
+
+#####
+##### Point evaluation of the reconstruction
+#####
+
+# Evaluate the reconstructions at `(x, y)`, measured from the centre of cell `(i, j)`. The point may lie
+# in a neighbouring cell, so the containing cell is located first and its own reconstruction is used.
+@inline function reconstruct(i, j, k, grid, x, y, ℵ, h, hs, r)
+    Δx = Δxᶜᶜᶜ(i, j, k, grid)
+    Δy = Δyᶜᶜᶜ(i, j, k, grid)
+
+    di = ifelse(x < -Δx/2, -1, ifelse(x > Δx/2, 1, 0))
+    dj = ifelse(y < -Δy/2, -1, ifelse(y > Δy/2, 1, 0))
+
+    I = i + di
+    J = j + dj
+
+    xc = ifelse(di == -1, -Δxᶠᶜᶜ(i, j, k, grid), ifelse(di == 1, Δxᶠᶜᶜ(i+1, j, k, grid), zero(grid)))
+    yc = ifelse(dj == -1, -Δyᶜᶠᶜ(i, j, k, grid), ifelse(dj == 1, Δyᶜᶠᶜ(i, j+1, k, grid), zero(grid)))
+
+    δx = x - xc
+    δy = y - yc
+
+    @inbounds begin
+        ℵ̃ = ℵ[I, J, k] + r.ℵx[I, J, 1] * δx + r.ℵy[I, J, 1] * δy
+        δxa = δx - r.xa[I, J, 1]
+        δya = δy - r.ya[I, J, 1]
+    end
+
+    h̃ = reconstruct_tracer(I, J, k, h, r.hx, r.hy, δxa, δya)
+    h̃s = reconstruct_tracer(I, J, k, hs, r.hsx, r.hsy, δxa, δya)
+
+    return max(ℵ̃, zero(ℵ̃)), h̃, h̃s
+end
+
+@inline reconstruct_tracer(I, J, k, ::Nothing, hx, hy, δx, δy) = zero(δx)
+@inline reconstruct_tracer(I, J, k, h, hx, hy, δx, δy) = @inbounds h[I, J, k] + hx[I, J, 1] * δx + hy[I, J, 1] * δy
+
+#####
+##### Transport through the swept region of a face
+#####
+
+# The region swept through the face is spanned by (x, y)(η, s) = p(η) - s Δt 𝐮(η) on (η, s) ∈ [0, 1]²,
+# where `p(η)` runs along the face and `𝐮(η)` is the corner velocity interpolated along it, in
+# coordinates local to the face midpoint. The Jacobian is signed, so a face whose normal velocity
+# changes sign along its length contributes the difference of the two lobes.
+@inline function x_face_transport(i, j, k, grid, ::Val{N}, Δt, u, v, ℵ, h, hs, r) where N
+    FT = eltype(grid)
+
+    Δy = Δyᶠᶜᶜ(i, j, k, grid)
+    xᶜ = Δxᶜᶜᶜ(i, j, k, grid) / 2
+
+    u₁ = ℑyᵃᶠᵃ(i, j,   k, grid, u)
+    v₁ = ℑxᶠᵃᵃ(i, j,   k, grid, v)
+    u₂ = ℑyᵃᶠᵃ(i, j+1, k, grid, u)
+    v₂ = ℑxᶠᵃᵃ(i, j+1, k, grid, v)
+
+    δu = u₂ - u₁
+    δv = v₂ - v₁
+
+    𝔉ℵ = zero(FT)
+    𝔉𝓋 = zero(FT)
+    𝔉𝓈 = zero(FT)
+
+    rule = quadrature_rule(FT, Val(N))
+
+    for (η, wη) in rule, (s, ws) in rule
+        uη = u₁ + η * δu
+        vη = v₁ + η * δv
+
+        x = - s * Δt * uη
+        y = - Δy/2 + η * Δy - s * Δt * vη
+
+        𝒥 = Δt * uη * Δy + s * Δt^2 * (δu * vη - uη * δv)
+
+        ℵ̃, h̃, h̃s = reconstruct(i, j, k, grid, x - xᶜ, y, ℵ, h, hs, r)
+
+        w = wη * ws * 𝒥
+        𝔉ℵ += w * ℵ̃
+        𝔉𝓋 += w * ℵ̃ * h̃
+        𝔉𝓈 += w * ℵ̃ * h̃s
+    end
+
+    return 𝔉ℵ, 𝔉𝓋, 𝔉𝓈
+end
+
+@inline function y_face_transport(i, j, k, grid, ::Val{N}, Δt, u, v, ℵ, h, hs, r) where N
+    FT = eltype(grid)
+
+    Δx = Δxᶜᶠᶜ(i, j, k, grid)
+    yᶜ = Δyᶜᶜᶜ(i, j, k, grid) / 2
+
+    u₁ = ℑyᵃᶠᵃ(i,   j, k, grid, u)
+    v₁ = ℑxᶠᵃᵃ(i,   j, k, grid, v)
+    u₂ = ℑyᵃᶠᵃ(i+1, j, k, grid, u)
+    v₂ = ℑxᶠᵃᵃ(i+1, j, k, grid, v)
+
+    δu = u₂ - u₁
+    δv = v₂ - v₁
+
+    𝔉ℵ = zero(FT)
+    𝔉𝓋 = zero(FT)
+    𝔉𝓈 = zero(FT)
+
+    rule = quadrature_rule(FT, Val(N))
+
+    for (ξ, wξ) in rule, (s, ws) in rule
+        uξ = u₁ + ξ * δu
+        vξ = v₁ + ξ * δv
+
+        x = - Δx/2 + ξ * Δx - s * Δt * uξ
+        y = - s * Δt * vξ
+
+        𝒥 = Δt * vξ * Δx + s * Δt^2 * (δv * uξ - vξ * δu)
+
+        ℵ̃, h̃, h̃s = reconstruct(i, j, k, grid, x, y - yᶜ, ℵ, h, hs, r)
+
+        w = wξ * ws * 𝒥
+        𝔉ℵ += w * ℵ̃
+        𝔉𝓋 += w * ℵ̃ * h̃
+        𝔉𝓈 += w * ℵ̃ * h̃s
+    end
+
+    return 𝔉ℵ, 𝔉𝓋, 𝔉𝓈
+end
+
+# Nothing crosses an immersed face.
+@inline mask_immersed_transport_x(i, j, k, grid, 𝔉) = 𝔉
+@inline mask_immersed_transport_y(i, j, k, grid, 𝔉) = 𝔉
+
+@inline mask_immersed_transport_x(i, j, k, ibg::ImmersedBoundaryGrid, 𝔉) =
+    conditional_flux_fcc(i, j, k, ibg, zero(ibg), 𝔉)
+
+@inline mask_immersed_transport_y(i, j, k, ibg::ImmersedBoundaryGrid, 𝔉) =
+    conditional_flux_cfc(i, j, k, ibg, zero(ibg), 𝔉)
+
+@kernel function _compute_x_transports!(transports, grid, nodes, Δt, u, v, ℵ, h, hs, reconstruction)
+    i, j = @index(Global, NTuple)
+    k = size(grid, 3)
+
+    𝔉ℵ, 𝔉𝓋, 𝔉𝓈 = x_face_transport(i, j, k, grid, nodes, Δt, u, v, ℵ, h, hs, reconstruction)
+
+    𝔉ℵ = mask_immersed_transport_x(i, j, k, grid, 𝔉ℵ)
+    𝔉𝓋 = mask_immersed_transport_x(i, j, k, grid, 𝔉𝓋)
+    𝔉𝓈 = mask_immersed_transport_x(i, j, k, grid, 𝔉𝓈)
+
+    @inbounds begin
+        transports.ℵ[i, j, 1] = 𝔉ℵ
+        transports.𝓋[i, j, 1] = 𝔉𝓋
+        transports.𝓋s[i, j, 1] = 𝔉𝓈
+    end
+end
+
+@kernel function _compute_y_transports!(transports, grid, nodes, Δt, u, v, ℵ, h, hs, reconstruction)
+    i, j = @index(Global, NTuple)
+    k = size(grid, 3)
+
+    𝔉ℵ, 𝔉𝓋, 𝔉𝓈 = y_face_transport(i, j, k, grid, nodes, Δt, u, v, ℵ, h, hs, reconstruction)
+
+    𝔉ℵ = mask_immersed_transport_y(i, j, k, grid, 𝔉ℵ)
+    𝔉𝓋 = mask_immersed_transport_y(i, j, k, grid, 𝔉𝓋)
+    𝔉𝓈 = mask_immersed_transport_y(i, j, k, grid, 𝔉𝓈)
+
+    @inbounds begin
+        transports.ℵ[i, j, 1] = 𝔉ℵ
+        transports.𝓋[i, j, 1] = 𝔉𝓋
+        transports.𝓋s[i, j, 1] = 𝔉𝓈
+    end
+end
+
+#####
+##### Tendencies
+#####
+
+@inline function transport_divergence(i, j, 𝔉x, 𝔉y)
+    @inbounds return 𝔉x[i+1, j, 1] - 𝔉x[i, j, 1] + 𝔉y[i, j+1, 1] - 𝔉y[i, j, 1]
+end
+
+@kernel function _compute_remapping_tendencies!(Gⁿ, grid, transports, Δt, snow_thickness)
+    i, j = @index(Global, NTuple)
+    k = size(grid, 3)
+
+    V = Azᶜᶜᶜ(i, j, k, grid) * Δt
+
+    @inbounds begin
+        Gⁿ.ℵ[i, j, 1] = - transport_divergence(i, j, transports.x.ℵ, transports.y.ℵ) / V
+        Gⁿ.h[i, j, 1] = - transport_divergence(i, j, transports.x.𝓋, transports.y.𝓋) / V
+    end
+
+    compute_remapping_snow_tendency!(i, j, Gⁿ, transports, V, snow_thickness)
+end
+
+@inline compute_remapping_snow_tendency!(i, j, Gⁿ, transports, V, ::Nothing) = nothing
+
+@inline function compute_remapping_snow_tendency!(i, j, Gⁿ, transports, V, snow_thickness)
+    @inbounds Gⁿ.hs[i, j, 1] = - transport_divergence(i, j, transports.x.𝓋s, transports.y.𝓋s) / V
+    return nothing
+end
+
+function compute_tracer_tendencies!(model::SIM, advection::IncrementalRemapping{N}, Δt) where N
+    grid = model.grid
+    arch = architecture(grid)
+
+    Nx, Ny, _ = size(grid)
+
+    ℵ = model.ice_concentration
+    h = model.ice_thickness
+    hs = model.snow_thickness
+
+    u = model.velocities.u
+    v = model.velocities.v
+
+    reconstruction = advection.reconstruction
+    transports = advection.transports
+
+    # The transport through a boundary face reads the reconstruction of the cell outside it, so the
+    # first halo cell is reconstructed too.
+    reconstruction_parameters = KernelParameters(0:Nx+1, 0:Ny+1)
+    launch!(arch, grid, reconstruction_parameters, _compute_remapping_reconstruction!, reconstruction, grid, ℵ, h, hs)
+
+    nodes = Val(N)
+
+    launch!(arch, grid, KernelParameters(1:Nx+1, 1:Ny), _compute_x_transports!, transports.x, grid, nodes, Δt, u, v, ℵ, h, hs, reconstruction)
+    launch!(arch, grid, KernelParameters(1:Nx, 1:Ny+1), _compute_y_transports!, transports.y, grid, nodes, Δt, u, v, ℵ, h, hs, reconstruction)
+    launch!(arch, grid, :xy, _compute_remapping_tendencies!, model.timestepper.Gⁿ, grid, transports, Δt, hs)
+
+    return nothing
+end
+
+
+function dynamic_time_step!(model::FESeaIceModel, ::IncrementalRemapping, Δt)
+    launch!(architecture(model), model.grid, :xy, _step_remapped_ice!,
+            model.ice_thickness, model.ice_concentration, model.snow_thickness,
+            model.timestepper.Gⁿ, Δt)
+    return nothing
+end
+
+@inline remapped_snow_content(i, j, ::Nothing, concentration) = nothing
+@inline remapped_snow_content(i, j, snow, concentration) = @inbounds snow[i, j, 1] * concentration
+
+# Recover thickness from transported volume, including concentration changes from ridging.
+@kernel function _step_remapped_ice!(h, ℵ, hs, tendencies, Δt)
+    i, j = @index(Global, NTuple)
+    @inbounds begin
+        concentration = ℵ[i, j, 1]
+        snow_volume = remapped_snow_content(i, j, hs, concentration)
+        volume = max(0, h[i, j, 1] * concentration + Δt * tendencies.h[i, j, 1])
+        concentration = max(0, concentration + Δt * tendencies.ℵ[i, j, 1])
+        empty = (volume <= 0) | (concentration <= 0)
+        concentration = ifelse(empty, zero(concentration), min(1, concentration))
+        h[i, j, 1] = ifelse(concentration > 0, volume / concentration, zero(volume))
+        ℵ[i, j, 1] = concentration
+    end
+    step_remapped_snow!(i, j, hs, snow_volume, concentration, tendencies, Δt)
+end
+
+@inline step_remapped_snow!(i, j, ::Nothing, args...) = nothing
+
+@inline function step_remapped_snow!(i, j, hs, snow_volume, concentration, tendencies, Δt)
+    @inbounds begin
+        volume = max(0, snow_volume + Δt * tendencies.hs[i, j, 1])
+        hs[i, j, 1] = ifelse(concentration > 0, volume / concentration, zero(volume))
+    end
+    return nothing
+end

--- a/src/sea_ice_fe_step.jl
+++ b/src/sea_ice_fe_step.jl
@@ -33,7 +33,9 @@ function Oceananigans.TimeSteppers.time_step!(model::FESeaIceModel, Δt; kwargs.
     return nothing
 end
 
-function dynamic_time_step!(model::FESeaIceModel, Δt)
+dynamic_time_step!(model::FESeaIceModel, Δt) = dynamic_time_step!(model, model.advection, Δt)
+
+function dynamic_time_step!(model::FESeaIceModel, advection, Δt)
     grid = model.grid
     arch = architecture(grid)
 

--- a/src/sea_ice_model.jl
+++ b/src/sea_ice_model.jl
@@ -262,6 +262,7 @@ function SeaIceModel(grid;
     # Fill any settings in advection scheme that might have been deferred until
     # the grid and backend is known
     advection = materialize_advection(advection, grid)
+    validate_advection_timestepper(advection, timestepper)
 
     # Package the external fluxes and boundary conditions
     external_heat_fluxes = (top = top_heat_flux,
@@ -297,6 +298,8 @@ function SeaIceModel(grid;
 end
 
 const SIM = SeaIceModel
+
+validate_advection_timestepper(advection, timestepper) = nothing
 
 function Oceananigans.Fields.set!(model::SIM; h=nothing, ℵ=nothing, hs=nothing, u=nothing, v=nothing)
     !isnothing(h)  && set!(model.ice_thickness, h)

--- a/src/tracer_tendency_kernel_functions.jl
+++ b/src/tracer_tendency_kernel_functions.jl
@@ -1,10 +1,13 @@
 using .SeaIceDynamics: compute_momentum_tendencies!
 
 function compute_tendencies!(model::SIM, Δt)
-    compute_tracer_tendencies!(model)
+    compute_tracer_tendencies!(model, model.advection, Δt)
     compute_momentum_tendencies!(model, model.dynamics, Δt)
     return nothing
 end
+
+# Keep the original entry point for schemes that only need the current state.
+compute_tracer_tendencies!(model::SIM, advection, Δt) = compute_tracer_tendencies!(model)
 
 function compute_tracer_tendencies!(model::SIM)
     grid = model.grid

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,7 @@ end
 
 if TEST_GROUP == "all" || TEST_GROUP == "advection"
     include("test_sea_ice_advection.jl")
+    include("test_incremental_remapping.jl")
 end
 
 if TEST_GROUP == "all" || TEST_GROUP == "basal_stress"

--- a/test/test_incremental_remapping.jl
+++ b/test/test_incremental_remapping.jl
@@ -1,0 +1,272 @@
+using Oceananigans.BoundaryConditions: fill_halo_regions!
+using Oceananigans.Operators: Δxᶜᶠᶜ, Δyᶠᶜᶜ
+
+# Remapping regression cases adapted from Simone Silvestri's commit 9334abd8.
+remapping_grid(Nx; halo = 4) =
+    RectilinearGrid(size = (Nx, Nx, 1), x = (0, 1), y = (0, 1), z = (-1, 0),
+                    halo = (halo, halo, halo), topology = (Periodic, Periodic, Bounded))
+
+# A discretely non-divergent swirl: u = -∂ψ/∂y, v = ∂ψ/∂x from a streamfunction at cell corners.
+function swirling_velocities(grid; amplitude = 0.1)
+    ψ = Field{Face, Face, Center}(grid)
+    set!(ψ, (x, y, z) -> amplitude / 2π * sin(2π * x) * sin(2π * y))
+    fill_halo_regions!(ψ)
+
+    u = Field{Face, Center, Center}(grid)
+    v = Field{Center, Face, Center}(grid)
+
+    Nx, Ny, _ = size(grid)
+    for i in 1:Nx, j in 1:Ny
+        u[i, j, 1] = - (ψ[i, j+1, 1] - ψ[i, j, 1]) / Δyᶠᶜᶜ(i, j, 1, grid)
+        v[i, j, 1] = + (ψ[i+1, j, 1] - ψ[i, j, 1]) / Δxᶜᶠᶜ(i, j, 1, grid)
+    end
+
+    fill_halo_regions!(u)
+    fill_halo_regions!(v)
+
+    return u, v
+end
+
+function remapping_model(grid, u, v; snow = false)
+    snow_thermodynamics = snow ? snow_slab_thermodynamics(grid) : nothing
+    return SeaIceModel(grid; velocities = (; u, v),
+                       advection = IncrementalRemapping(),
+                       ice_thermodynamics = nothing,
+                       snow_thermodynamics,
+                       dynamics = nothing,
+                       timestepper = :ForwardEuler)
+end
+
+@testset "Incremental remapping requirements" begin
+    @info "Testing incremental remapping constructor requirements"
+
+    grid = remapping_grid(8)
+
+    # The transport integrates over the step, so it is a Forward-Euler scheme by construction.
+    @test_throws ArgumentError SeaIceModel(grid; advection = IncrementalRemapping())
+    @test SeaIceModel(grid; advection = IncrementalRemapping(),
+                      timestepper = :ForwardEuler) isa SeaIceModel
+
+    thin = remapping_grid(8; halo = 1)
+    @test_throws ArgumentError SeaIceModel(thin; advection = IncrementalRemapping(),
+                                           timestepper = :ForwardEuler)
+end
+
+@testset "Incremental remapping bounds the recovered thickness" begin
+    @info "Testing that incremental remapping keeps h = 𝓋/ℵ bounded"
+
+    grid = remapping_grid(64)
+    u, v = swirling_velocities(grid)
+    model = remapping_model(grid, u, v; snow = true)
+
+    # Discontinuous concentration carried by a sheared flow, with uniform thickness: the exact answer
+    # keeps h ≡ 1.5 and hs ≡ 0.3 wherever ice is present. Independently advecting ℵ and 𝓋 = ℵh cannot
+    # do this — the ratio is unbounded as ℵ → 0.
+    iced(x, y) = ((x - 1/2)^2 + (y - 1/2)^2) < 0.2^2
+    set!(model, ℵ = (x, y) -> iced(x, y) ? 1.0 : 0.0,
+                h = (x, y) -> iced(x, y) ? 1.5 : 0.0,
+                hs = (x, y) -> iced(x, y) ? 0.3 : 0.0)
+
+    for _ in 1:200
+        time_step!(model, 0.02)
+    end
+
+    h = Array(interior(model.ice_thickness))
+    hs = Array(interior(model.snow_thickness))
+    ℵ = Array(interior(model.ice_concentration))
+
+    @test maximum(h) ≤ 1.5 * (1 + 1e-4)
+    @test maximum(hs) ≤ 0.3 * (1 + 1e-4)
+    @test maximum(ℵ) ≤ 1
+    @test minimum(ℵ) ≥ 0
+end
+
+@testset "Incremental remapping is exact for uniform translation" begin
+    @info "Testing incremental remapping under uniform translation"
+
+    grid = remapping_grid(48)
+
+    u = Field{Face, Center, Center}(grid); set!(u, 0.1); fill_halo_regions!(u)
+    v = Field{Center, Face, Center}(grid); set!(v, 0.037); fill_halo_regions!(v)
+
+    model = remapping_model(grid, u, v)
+
+    iced(x, y) = ((x - 1/2)^2 + (y - 1/2)^2) < 0.2^2
+    set!(model, ℵ = (x, y) -> iced(x, y) ? 1.0 : 0.0,
+                h = (x, y) -> iced(x, y) ? 1.5 : 0.0)
+
+    for _ in 1:100
+        time_step!(model, 0.05)
+    end
+
+    # Without shear the swept region never straddles a cell boundary and the transport is exact, so
+    # the thickness is bounded to round-off.
+    @test maximum(interior(model.ice_thickness)) ≤ 1.5 * (1 + 1e-12)
+end
+
+@testset "Incremental remapping conserves ∫(ℵ·h) dA" begin
+    @info "Testing incremental remapping conservation"
+
+    grid = remapping_grid(48)
+    u, v = swirling_velocities(grid)
+    model = remapping_model(grid, u, v; snow = true)
+
+    set!(model, ℵ = (x, y) -> 0.5 + 0.4 * sin(2π * x) * cos(2π * y), h = 1.5, hs = 0.3)
+
+    content(m) = Field(Integral(m.ice_concentration * m.ice_thickness))[1, 1, 1]
+    snow(m) = Field(Integral(m.ice_concentration * m.snow_thickness))[1, 1, 1]
+
+    𝓋₀, 𝓋s₀ = content(model), snow(model)
+
+    for _ in 1:100
+        time_step!(model, 0.02)
+    end
+
+    @test isapprox(content(model), 𝓋₀; rtol = 1e-12)
+    @test isapprox(snow(model), 𝓋s₀; rtol = 1e-12)
+
+    # A uniform thickness stays uniform: the transported content and area come from the same region.
+    @test maximum(interior(model.ice_thickness)) ≈ 1.5
+    @test minimum(interior(model.ice_thickness)) ≈ 1.5
+end
+
+@testset "Incremental remapping needs no minimum concentration" begin
+    @info "Testing that incremental remapping conserves content without emptying cells"
+
+    # Flux-form advection empties any cell whose concentration collapses, because the thickness it
+    # recovers there is meaningless. That discards content. Incremental remapping bounds the ratio at
+    # any concentration, so it keeps the floor at zero and conserves to round-off even when the
+    # concentration is discontinuous.
+    @test ClimaSeaIce.minimum_ice_concentration(Float64, IncrementalRemapping()) == 0
+
+    grid = remapping_grid(48)
+    u, v = swirling_velocities(grid)
+    model = remapping_model(grid, u, v)
+
+    iced(x, y) = ((x - 1/2)^2 + (y - 1/2)^2) < 0.2^2
+    set!(model, ℵ = (x, y) -> iced(x, y) ? 1.0 : 0.0,
+                h = (x, y) -> iced(x, y) ? 1.5 : 0.0)
+
+    content(m) = Field(Integral(m.ice_concentration * m.ice_thickness))[1, 1, 1]
+    𝓋₀ = content(model)
+
+    for _ in 1:200
+        time_step!(model, 0.02)
+    end
+
+    @test isapprox(content(model), 𝓋₀; rtol = 1e-12)
+    @test minimum(interior(model.ice_concentration)) ≥ 0
+end
+
+@testset "Incremental remapping is second-order accurate" begin
+    @info "Testing incremental remapping convergence rate"
+
+    function translation_error(Nx; courant = 0.25)
+        grid = remapping_grid(Nx)
+
+        u = Field{Face, Center, Center}(grid); set!(u, 1); fill_halo_regions!(u)
+        v = Field{Center, Face, Center}(grid); set!(v, 0); fill_halo_regions!(v)
+
+        model = remapping_model(grid, u, v)
+        set!(model, ℵ = (x, y) -> 0.5 + 0.4 * sin(2π * x) * cos(2π * y), h = 1.5)
+
+        ℵ₀ = Array(interior(model.ice_concentration))
+
+        steps = round(Int, Nx / courant)
+        for _ in 1:steps
+            time_step!(model, 1 / steps)
+        end
+
+        ℵ = Array(interior(model.ice_concentration))
+        return sum(abs, ℵ .- ℵ₀) / length(ℵ)
+    end
+
+    errors = translation_error.((16, 32, 64))
+    orders = log2.(errors[1:end-1] ./ errors[2:end])
+
+    @test all(orders .> 1.8)
+end
+
+@testset "Incremental remapping across an immersed boundary" begin
+    @info "Testing incremental remapping against an immersed island"
+
+    underlying_grid = remapping_grid(48)
+    island(x, y, z) = ((x - 1/2)^2 + (y - 1/2)^2) < 0.12^2
+    grid = ImmersedBoundaryGrid(underlying_grid, GridFittedBoundary(island))
+
+    u = Field{Face, Center, Center}(grid); set!(u, 0.1); fill_halo_regions!(u)
+    v = Field{Center, Face, Center}(grid); set!(v, 0.037); fill_halo_regions!(v)
+
+    model = remapping_model(grid, u, v)
+    set!(model, ℵ = 0.3, h = 1.5)
+    Oceananigans.TimeSteppers.update_state!(model)
+
+    content(m) = sum(interior(m.ice_concentration, :, :, 1) .* interior(m.ice_thickness, :, :, 1))
+    𝓋₀ = content(model)
+
+    for _ in 1:200
+        time_step!(model, 0.02)
+    end
+
+    ℵ = Array(interior(model.ice_concentration, :, :, 1))
+    solid = [ClimaSeaIce.submerged(i, j, 1, grid) for i in 1:size(grid, 1), j in 1:size(grid, 2)]
+
+    # Nothing crosses an immersed face and no reconstruction reaches into land, so ice driven onto a
+    # coast is conserved rather than deposited on it.
+    @test maximum(ℵ[solid]; init = 0.0) == 0
+    @test isapprox(content(model), 𝓋₀; rtol = 1e-10)
+    @test minimum(ℵ) ≥ 0
+    @test all(isfinite, interior(model.ice_thickness))
+end
+
+@testset "Incremental remapping on a TripolarGrid" begin
+    @info "Testing incremental remapping across the tripolar fold"
+
+    grid = TripolarGrid(size = (40, 40, 1), z = (-1, 0), halo = (4, 4, 4))
+
+    bcs = name -> ClimaSeaIce.default_sea_ice_boundary_conditions(grid, name)
+    u = Field{Face, Center, Nothing}(grid, boundary_conditions = bcs(:u))
+    v = Field{Center, Face, Nothing}(grid, boundary_conditions = bcs(:v))
+    set!(u, (λ, φ) -> 0.2 * sind(2λ) * cosd(φ))
+    set!(v, (λ, φ) -> 0.1 * cosd(2λ))
+    fill_halo_regions!(u)
+    fill_halo_regions!(v)
+
+    model = SeaIceModel(grid; velocities = (; u, v),
+                        advection = IncrementalRemapping(),
+                        ice_thermodynamics = nothing,
+                        dynamics = nothing,
+                        timestepper = :ForwardEuler)
+
+    iced(φ) = φ > 55
+    set!(model, ℵ = (λ, φ) -> iced(φ) ? 0.3 : 0.0, h = (λ, φ) -> iced(φ) ? 1.5 : 0.0)
+
+    for _ in 1:100
+        time_step!(model, 3600)
+    end
+
+    h = Array(interior(model.ice_thickness))
+    ℵ = Array(interior(model.ice_concentration))
+
+    # The reconstruction gradients are computed directly in the halo, which gives them the sign the
+    # fold requires without a separate signed halo exchange.
+    @test maximum(h) ≤ 1.5 * (1 + 1e-8)
+    @test maximum(ℵ) ≤ 1
+    @test minimum(ℵ) ≥ 0
+    @test all(isfinite, h)
+end
+
+
+@testset "Remapping restart from Runge-Kutta fields" begin
+    grid = remapping_grid(8)
+    previous = SeaIceModel(grid; advection=WENO(), ice_thermodynamics=nothing)
+    set!(previous, h=2, ℵ=0.4)
+    model = SeaIceModel(grid; advection=IncrementalRemapping(), timestepper=:ForwardEuler,
+                       ice_thermodynamics=nothing)
+    state = Oceananigans.prognostic_state(previous)
+    Oceananigans.restore_prognostic_state!(model, state)
+    @test Array(interior(model.ice_thickness)) == Array(interior(previous.ice_thickness))
+    @test Array(interior(model.ice_concentration)) == Array(interior(previous.ice_concentration))
+    time_step!(model, 0.01)
+    @test maximum(interior(model.ice_thickness)) ≈ 2
+end


### PR DESCRIPTION
Add opt-in `IncrementalRemapping` sea-ice advection, backported from Simone Silvestri's `ss/for-omip` implementation at f9a579ad9869d9b04cf3d052267c5fcce22c0baf. The scheme transports concentration, ice volume, and snow volume together, then recovers thickness after transport and ridging.

The backport adds the remapping kernels, checks for the required Forward Euler timestepper and horizontal halos, and a dedicated volume-based update. Existing advection schemes retain their current update path. Forward Euler can restart from saved Runge-Kutta fields without restoring unused timestepper history.

Validation: ClimaSeaIce and NumericalEarth precompiled and loaded successfully; syntax and whitespace checks pass. Added upstream remapping regression cases covering bounds, conservation, convergence, immersed boundaries, the tripolar fold, and a restart regression. Tests have not been run locally; GitHub CI handles test execution. GPU execution remains unverified.
